### PR TITLE
Uart_package_&_Wifi_esp32_transmitter&receiver_&_PC_python

### DIFF
--- a/CNN_RPI_SHT40_uart_packet/README.md
+++ b/CNN_RPI_SHT40_uart_packet/README.md
@@ -1,0 +1,17 @@
+# CNN RPi SHT40 UART Packet (FPGA/HDL)
+
+이 폴더는 Basys3 FPGA 보드에서 동작하는 SystemVerilog 소스 코드를 포함하고 있습니다.
+
+## 주요 기능
+- **SHT40 제어**: I2C 통신을 통해 SHT40 온습도 센서 데이터를 읽어옵니다.
+- **CNN UART 패키지**: RPi(라즈베리 파이) 및 하위 시스템과 통신하기 위한 고유 패키지 구조를 생성합니다.
+- **UART 전송**: 수집된 센서 데이터 및 상태 정보를 정해진 프로토콜에 맞춰 외부(ESP32)로 전송합니다.
+
+## 주요 모듈 구성
+- `UART_RPI_CNN_TOP.sv`: 전체 시스템의 최상위 모듈
+- `sht40_i2c.sv`: SHT40 센서 I2C 인터페이스 로직
+- `packet_builder.sv`: 데이터를 전송 규격에 맞게 패킷화하는 로직
+- `uart_tx.sv / uart_rx.sv`: UART 통신 물리 계층 구현
+
+## 비고
+- Vivado 프로젝트에서 `sources_1` 및 `constrs_1`을 참조하여 빌드하십시오.

--- a/CNN_RPI_SHT40_uart_packet/constrs_1/imports/digilent-xdc-master_2/Basys-3-Master.xdc
+++ b/CNN_RPI_SHT40_uart_packet/constrs_1/imports/digilent-xdc-master_2/Basys-3-Master.xdc
@@ -1,0 +1,159 @@
+## This file is a general .xdc for the Basys3 rev B board
+## To use it in a project:
+## - uncomment the lines corresponding to used pins
+## - rename the used ports (in each line, after get_ports) according to the top level signal names in the project
+
+## Clock signal
+set_property -dict { PACKAGE_PIN W5   IOSTANDARD LVCMOS33 } [get_ports clk]
+create_clock -add -name sys_clk_pin -period 10.00 -waveform {0 5} [get_ports clk]
+
+
+## Switches
+#set_property -dict { PACKAGE_PIN V17   IOSTANDARD LVCMOS33 } [get_ports {sw[0]}]
+#set_property -dict { PACKAGE_PIN V16   IOSTANDARD LVCMOS33 } [get_ports {sw[1]}]
+#set_property -dict { PACKAGE_PIN W16   IOSTANDARD LVCMOS33 } [get_ports {sw[2]}]
+#set_property -dict { PACKAGE_PIN W17   IOSTANDARD LVCMOS33 } [get_ports {sw[3]}]
+#set_property -dict { PACKAGE_PIN W15   IOSTANDARD LVCMOS33 } [get_ports {sw[4]}]
+#set_property -dict { PACKAGE_PIN V15   IOSTANDARD LVCMOS33 } [get_ports {sw[5]}]
+#set_property -dict { PACKAGE_PIN W14   IOSTANDARD LVCMOS33 } [get_ports {sw[6]}]
+#set_property -dict { PACKAGE_PIN W13   IOSTANDARD LVCMOS33 } [get_ports {sw[7]}]
+#set_property -dict { PACKAGE_PIN V2    IOSTANDARD LVCMOS33 } [get_ports {sw[8]}]
+#set_property -dict { PACKAGE_PIN T3    IOSTANDARD LVCMOS33 } [get_ports {sw[9]}]
+#set_property -dict { PACKAGE_PIN T2    IOSTANDARD LVCMOS33 } [get_ports {sw[10]}]
+#set_property -dict { PACKAGE_PIN R3    IOSTANDARD LVCMOS33 } [get_ports {sw[11]}]
+#set_property -dict { PACKAGE_PIN W2    IOSTANDARD LVCMOS33 } [get_ports {sw[12]}]
+#set_property -dict { PACKAGE_PIN U1    IOSTANDARD LVCMOS33 } [get_ports {sw[13]}]
+#set_property -dict { PACKAGE_PIN T1    IOSTANDARD LVCMOS33 } [get_ports {sw[14]}]
+#set_property -dict { PACKAGE_PIN R2    IOSTANDARD LVCMOS33 } [get_ports {sw[15]}]
+
+
+## LEDs
+set_property -dict { PACKAGE_PIN U16   IOSTANDARD LVCMOS33 } [get_ports led_tx_active]
+set_property -dict { PACKAGE_PIN E19   IOSTANDARD LVCMOS33 } [get_ports led_rpi_active]
+set_property -dict { PACKAGE_PIN U19   IOSTANDARD LVCMOS33 } [get_ports led_cnn_active]
+#set_property -dict { PACKAGE_PIN V19   IOSTANDARD LVCMOS33 } [get_ports {led[3]}]
+#set_property -dict { PACKAGE_PIN W18   IOSTANDARD LVCMOS33 } [get_ports {led[4]}]
+#set_property -dict { PACKAGE_PIN U15   IOSTANDARD LVCMOS33 } [get_ports {led[5]}]
+#set_property -dict { PACKAGE_PIN U14   IOSTANDARD LVCMOS33 } [get_ports {led[6]}]
+#set_property -dict { PACKAGE_PIN V14   IOSTANDARD LVCMOS33 } [get_ports {led[7]}]
+#set_property -dict { PACKAGE_PIN V13   IOSTANDARD LVCMOS33 } [get_ports {led[8]}]
+#set_property -dict { PACKAGE_PIN V3    IOSTANDARD LVCMOS33 } [get_ports {led[9]}]
+#set_property -dict { PACKAGE_PIN W3    IOSTANDARD LVCMOS33 } [get_ports {led[10]}]
+#set_property -dict { PACKAGE_PIN U3    IOSTANDARD LVCMOS33 } [get_ports {led[11]}]
+#set_property -dict { PACKAGE_PIN P3    IOSTANDARD LVCMOS33 } [get_ports {led[12]}]
+#set_property -dict { PACKAGE_PIN N3    IOSTANDARD LVCMOS33 } [get_ports {led[13]}]
+#set_property -dict { PACKAGE_PIN P1    IOSTANDARD LVCMOS33 } [get_ports {led[14]}]
+#set_property -dict { PACKAGE_PIN L1    IOSTANDARD LVCMOS33 } [get_ports {led[15]}]
+
+
+##7 Segment Display
+#set_property -dict { PACKAGE_PIN W7   IOSTANDARD LVCMOS33 } [get_ports {seg[0]}]
+#set_property -dict { PACKAGE_PIN W6   IOSTANDARD LVCMOS33 } [get_ports {seg[1]}]
+#set_property -dict { PACKAGE_PIN U8   IOSTANDARD LVCMOS33 } [get_ports {seg[2]}]
+#set_property -dict { PACKAGE_PIN V8   IOSTANDARD LVCMOS33 } [get_ports {seg[3]}]
+#set_property -dict { PACKAGE_PIN U5   IOSTANDARD LVCMOS33 } [get_ports {seg[4]}]
+#set_property -dict { PACKAGE_PIN V5   IOSTANDARD LVCMOS33 } [get_ports {seg[5]}]
+#set_property -dict { PACKAGE_PIN U7   IOSTANDARD LVCMOS33 } [get_ports {seg[6]}]
+
+#set_property -dict { PACKAGE_PIN V7   IOSTANDARD LVCMOS33 } [get_ports dp]
+
+#set_property -dict { PACKAGE_PIN U2   IOSTANDARD LVCMOS33 } [get_ports {an[0]}]
+#set_property -dict { PACKAGE_PIN U4   IOSTANDARD LVCMOS33 } [get_ports {an[1]}]
+#set_property -dict { PACKAGE_PIN V4   IOSTANDARD LVCMOS33 } [get_ports {an[2]}]
+#set_property -dict { PACKAGE_PIN W4   IOSTANDARD LVCMOS33 } [get_ports {an[3]}]
+
+
+##Buttons
+set_property -dict { PACKAGE_PIN U18   IOSTANDARD LVCMOS33 } [get_ports rst]
+#set_property -dict { PACKAGE_PIN T18   IOSTANDARD LVCMOS33 } [get_ports btnU]
+#set_property -dict { PACKAGE_PIN W19   IOSTANDARD LVCMOS33 } [get_ports btnL]
+#set_property -dict { PACKAGE_PIN T17   IOSTANDARD LVCMOS33 } [get_ports btnR]
+#set_property -dict { PACKAGE_PIN U17   IOSTANDARD LVCMOS33 } [get_ports btnD]
+
+
+##Pmod Header JA
+#set_property -dict { PACKAGE_PIN J1   IOSTANDARD LVCMOS33 } [get_ports {JA[0]}];#Sch name = JA1
+#set_property -dict { PACKAGE_PIN L2   IOSTANDARD LVCMOS33 } [get_ports {JA[1]}];#Sch name = JA2
+#set_property -dict { PACKAGE_PIN J2   IOSTANDARD LVCMOS33 } [get_ports {JA[2]}];#Sch name = JA3
+#set_property -dict { PACKAGE_PIN G2   IOSTANDARD LVCMOS33 } [get_ports {JA[3]}];#Sch name = JA4
+#set_property -dict { PACKAGE_PIN H1   IOSTANDARD LVCMOS33 } [get_ports {JA[4]}];#Sch name = JA7
+#set_property -dict { PACKAGE_PIN K2   IOSTANDARD LVCMOS33 } [get_ports {JA[5]}];#Sch name = JA8
+#set_property -dict { PACKAGE_PIN H2   IOSTANDARD LVCMOS33 } [get_ports {JA[6]}];#Sch name = JA9
+#set_property -dict { PACKAGE_PIN G3   IOSTANDARD LVCMOS33 } [get_ports {JA[7]}];#Sch name = JA10
+
+##Pmod Header JB
+#set_property -dict { PACKAGE_PIN A14   IOSTANDARD LVCMOS33 } [get_ports {JB[0]}];#Sch name = JB1
+#set_property -dict { PACKAGE_PIN A16   IOSTANDARD LVCMOS33 } [get_ports {JB[1]}];#Sch name = JB2
+#set_property -dict { PACKAGE_PIN B15   IOSTANDARD LVCMOS33 } [get_ports {JB[2]}];#Sch name = JB3
+#set_property -dict { PACKAGE_PIN B16   IOSTANDARD LVCMOS33 } [get_ports {JB[3]}];#Sch name = JB4
+#set_property -dict { PACKAGE_PIN A15   IOSTANDARD LVCMOS33 } [get_ports {JB[4]}];#Sch name = JB7
+#set_property -dict { PACKAGE_PIN A17   IOSTANDARD LVCMOS33 } [get_ports {JB[5]}];#Sch name = JB8
+#set_property -dict { PACKAGE_PIN C15   IOSTANDARD LVCMOS33 } [get_ports {JB[6]}];#Sch name = JB9
+#set_property -dict { PACKAGE_PIN C16   IOSTANDARD LVCMOS33 } [get_ports {JB[7]}];#Sch name = JB10
+
+##Pmod Header JC
+set_property -dict { PACKAGE_PIN K17   IOSTANDARD LVCMOS33 } [get_ports uart_tx_pin];#Sch name = JC1
+set_property -dict { PACKAGE_PIN M18   IOSTANDARD LVCMOS33 } [get_ports uart_rx_pin];#Sch name = JC2
+set_property -dict { PACKAGE_PIN N17   IOSTANDARD LVCMOS33 } [get_ports rpi_signal];#Sch name = JC3
+set_property -dict { PACKAGE_PIN P18   IOSTANDARD LVCMOS33 } [get_ports cnn_signal];#Sch name = JC4
+set_property -dict { PACKAGE_PIN L17   IOSTANDARD LVCMOS33 } [get_ports sht_i2c_scl];#Sch name = JC7
+set_property -dict { PACKAGE_PIN M19   IOSTANDARD LVCMOS33 } [get_ports sht_i2c_sda];#Sch name = JC8
+#set_property -dict { PACKAGE_PIN P17   IOSTANDARD LVCMOS33 } [get_ports ];#Sch name = JC9
+#set_property -dict { PACKAGE_PIN R18   IOSTANDARD LVCMOS33 } [get_ports {JC[7]}];#Sch name = JC10
+
+##Pmod Header JXADC
+#set_property -dict { PACKAGE_PIN J3   IOSTANDARD LVCMOS33 } [get_ports {JXADC[0]}];#Sch name = XA1_P
+#set_property -dict { PACKAGE_PIN L3   IOSTANDARD LVCMOS33 } [get_ports {JXADC[1]}];#Sch name = XA2_P
+#set_property -dict { PACKAGE_PIN M2   IOSTANDARD LVCMOS33 } [get_ports {JXADC[2]}];#Sch name = XA3_P
+#set_property -dict { PACKAGE_PIN N2   IOSTANDARD LVCMOS33 } [get_ports {JXADC[3]}];#Sch name = XA4_P
+#set_property -dict { PACKAGE_PIN K3   IOSTANDARD LVCMOS33 } [get_ports {JXADC[4]}];#Sch name = XA1_N
+#set_property -dict { PACKAGE_PIN M3   IOSTANDARD LVCMOS33 } [get_ports {JXADC[5]}];#Sch name = XA2_N
+#set_property -dict { PACKAGE_PIN M1   IOSTANDARD LVCMOS33 } [get_ports {JXADC[6]}];#Sch name = XA3_N
+#set_property -dict { PACKAGE_PIN N1   IOSTANDARD LVCMOS33 } [get_ports {JXADC[7]}];#Sch name = XA4_N
+
+
+##VGA Connector
+#set_property -dict { PACKAGE_PIN G19   IOSTANDARD LVCMOS33 } [get_ports {vgaRed[0]}]
+#set_property -dict { PACKAGE_PIN H19   IOSTANDARD LVCMOS33 } [get_ports {vgaRed[1]}]
+#set_property -dict { PACKAGE_PIN J19   IOSTANDARD LVCMOS33 } [get_ports {vgaRed[2]}]
+#set_property -dict { PACKAGE_PIN N19   IOSTANDARD LVCMOS33 } [get_ports {vgaRed[3]}]
+#set_property -dict { PACKAGE_PIN N18   IOSTANDARD LVCMOS33 } [get_ports {vgaBlue[0]}]
+#set_property -dict { PACKAGE_PIN L18   IOSTANDARD LVCMOS33 } [get_ports {vgaBlue[1]}]
+#set_property -dict { PACKAGE_PIN K18   IOSTANDARD LVCMOS33 } [get_ports {vgaBlue[2]}]
+#set_property -dict { PACKAGE_PIN J18   IOSTANDARD LVCMOS33 } [get_ports {vgaBlue[3]}]
+#set_property -dict { PACKAGE_PIN J17   IOSTANDARD LVCMOS33 } [get_ports {vgaGreen[0]}]
+#set_property -dict { PACKAGE_PIN H17   IOSTANDARD LVCMOS33 } [get_ports {vgaGreen[1]}]
+#set_property -dict { PACKAGE_PIN G17   IOSTANDARD LVCMOS33 } [get_ports {vgaGreen[2]}]
+#set_property -dict { PACKAGE_PIN D17   IOSTANDARD LVCMOS33 } [get_ports {vgaGreen[3]}]
+#set_property -dict { PACKAGE_PIN P19   IOSTANDARD LVCMOS33 } [get_ports Hsync]
+#set_property -dict { PACKAGE_PIN R19   IOSTANDARD LVCMOS33 } [get_ports Vsync]
+
+
+##USB-RS232 Interface
+#set_property -dict { PACKAGE_PIN B18   IOSTANDARD LVCMOS33 } [get_ports RsRx]
+#set_property -dict { PACKAGE_PIN A18   IOSTANDARD LVCMOS33 } [get_ports RsTx]
+
+
+##USB HID (PS/2)
+#set_property -dict { PACKAGE_PIN C17   IOSTANDARD LVCMOS33   PULLUP true } [get_ports PS2Clk]
+#set_property -dict { PACKAGE_PIN B17   IOSTANDARD LVCMOS33   PULLUP true } [get_ports PS2Data]
+
+
+##Quad SPI Flash
+##Note that CCLK_0 cannot be placed in 7 series devices. You can access it using the
+##STARTUPE2 primitive.
+#set_property -dict { PACKAGE_PIN D18   IOSTANDARD LVCMOS33 } [get_ports {QspiDB[0]}]
+#set_property -dict { PACKAGE_PIN D19   IOSTANDARD LVCMOS33 } [get_ports {QspiDB[1]}]
+#set_property -dict { PACKAGE_PIN G18   IOSTANDARD LVCMOS33 } [get_ports {QspiDB[2]}]
+#set_property -dict { PACKAGE_PIN F18   IOSTANDARD LVCMOS33 } [get_ports {QspiDB[3]}]
+#set_property -dict { PACKAGE_PIN K19   IOSTANDARD LVCMOS33 } [get_ports QspiCSn]
+
+
+## Configuration options, can be used for all designs
+set_property CONFIG_VOLTAGE 3.3 [current_design]
+set_property CFGBVS VCCO [current_design]
+
+## SPI configuration mode options for QSPI boot, can be used for all designs
+set_property BITSTREAM.GENERAL.COMPRESS TRUE [current_design]
+set_property BITSTREAM.CONFIG.CONFIGRATE 33 [current_design]
+set_property CONFIG_MODE SPIx4 [current_design]

--- a/CNN_RPI_SHT40_uart_packet/sources_1/imports/new/UART_RPI_CNN_TOP.sv
+++ b/CNN_RPI_SHT40_uart_packet/sources_1/imports/new/UART_RPI_CNN_TOP.sv
@@ -1,0 +1,103 @@
+`timescale 1ns / 1ps
+//=============================================================================
+// Module  : UART_RPI_CNN_TOP
+// Purpose : Top-level module for RPi, CNN, and SHT40 Sensor Integration.
+//=============================================================================
+module UART_RPI_CNN_TOP (
+    input  logic clk,              // 100 MHz
+    input  logic rst,              // Active-High Reset
+
+    output logic uart_tx_pin,      
+    input  logic uart_rx_pin,      
+
+    input  logic rpi_signal,       // RPi GPIO (1-sec toggle on crisis)
+    input  logic cnn_signal,       // Z7-20에서 오는 단일 선
+
+    // SHT40 I2C Interface
+    inout  wire  sht_i2c_sda,
+    output logic sht_i2c_scl,
+
+    output logic led_tx_active,    
+    output logic led_rpi_active,   
+    output logic led_cnn_active    
+);
+
+    // 내부 신호 선언
+    logic        baud_tick;
+    logic [7:0]  tx_data;
+    logic        tx_start, tx_busy, tx_done;
+    logic [7:0]  rx_data;
+    logic        rx_done;
+    
+    logic        rpi_event, rpi_active;
+    logic [7:0]  cnn_data;
+    logic        cnn_event;
+    
+    logic        sht_event;
+    logic [31:0] sht_data;
+
+    logic [7:0]  cmd_out, cmd_payload;
+    logic        cmd_valid;
+
+    // Baud Rate Generator (115200)
+    baud_gen #(.CLK_FREQ(100_000_000), .BAUD_RATE(115_200)) u_baud_gen (
+        .clk(clk), .rst(rst), .tick(baud_tick)
+    );
+
+    // UART Modules
+    uart_tx u_uart_tx (
+        .clk(clk), .rst(rst), .baud_tick(baud_tick),
+        .start(tx_start), .data(tx_data), .tx(uart_tx_pin),
+        .busy(tx_busy), .done(tx_done)
+    );
+
+    uart_rx #(.CLK_FREQ(100_000_000), .BAUD_RATE(115_200)) u_uart_rx (
+        .clk(clk), .rst(rst), .rx(uart_rx_pin),
+        .rx_data(rx_data), .rx_done(rx_done), .rx_error()
+    );
+
+    // RPi Detector (posedge only)
+    rpi_det u_rpi_det (
+        .clk(clk), .rst(rst), .rpi_signal(rpi_signal),
+        .rpi_event(rpi_event), .rpi_active(rpi_active)
+    );
+
+    // CNN Latch (단일 신호 모드로 변경된 모듈 연결)
+    cnn_latch u_cnn_latch (
+        .clk(clk), 
+        .rst(rst), 
+        .cnn_signal(cnn_signal),   // cnn_valid 대신 cnn_signal 연결
+        .cnn_data(cnn_data), 
+        .cnn_event(cnn_event)
+    );
+
+    // SHT40 I2C Controller
+    sht40_i2c #(.CLK_FREQ(100_000_000)) u_sht40_ctrl (
+        .clk(clk), .rst(rst),
+        .i2c_sda(sht_i2c_sda), .i2c_scl(sht_i2c_scl),
+        .sht_data(sht_data), .sht_valid(sht_event)
+    );
+
+    // Packet Builder (SHT40 Multi-byte Support)
+    packet_builder u_pkt_builder (
+        .clk(clk), .rst(rst),
+        .rpi_event(rpi_event), .rpi_active(rpi_active),
+        .cnn_event(cnn_event), .cnn_data(cnn_data),
+        .sht_event(sht_event), .sht_data(sht_data),
+        .tx_busy(tx_busy), .tx_done(tx_done),
+        .tx_start(tx_start), .tx_byte(tx_data)
+    );
+
+    // Command Decoder
+    cmd_decoder u_cmd_decoder (
+        .clk(clk), .rst(rst),
+        .rx_data(rx_data), .rx_done(rx_done),
+        .cmd_out(cmd_out), .cmd_payload(cmd_payload), .cmd_valid(cmd_valid)
+    );
+
+    // Status LEDs
+    assign led_tx_active  = tx_busy;
+    assign led_rpi_active = rpi_active;
+    assign led_cnn_active = cnn_event;
+
+endmodule

--- a/CNN_RPI_SHT40_uart_packet/sources_1/imports/new/baud_gen.sv
+++ b/CNN_RPI_SHT40_uart_packet/sources_1/imports/new/baud_gen.sv
@@ -1,0 +1,34 @@
+`timescale 1ns / 1ps
+//=============================================================================
+// Module  : baud_gen
+// Purpose : Generate baud-rate tick (1 pulse per bit period)
+// Params  : CLK_FREQ  - system clock frequency in Hz  (default 100 MHz)
+//           BAUD_RATE - desired baud rate in bps       (default 115200)
+//=============================================================================
+module baud_gen #(
+    parameter int CLK_FREQ  = 100_000_000,
+    parameter int BAUD_RATE = 115_200
+)(
+    input  logic clk,
+    input  logic rst,
+    output logic tick        // 1-cycle pulse every bit period
+);
+
+    localparam int DIVISOR = CLK_FREQ / BAUD_RATE;  // 868 @ 100MHz/115200
+
+    logic [$clog2(DIVISOR)-1:0] cnt;
+
+    always_ff @(posedge clk or posedge rst) begin
+        if (rst) begin
+            cnt  <= '0;
+            tick <= 1'b0;
+        end else if (cnt == DIVISOR - 1) begin
+            cnt  <= '0;
+            tick <= 1'b1;
+        end else begin
+            cnt  <= cnt + 1'b1;
+            tick <= 1'b0;
+        end
+    end
+
+endmodule

--- a/CNN_RPI_SHT40_uart_packet/sources_1/imports/new/cmd_decoder.sv
+++ b/CNN_RPI_SHT40_uart_packet/sources_1/imports/new/cmd_decoder.sv
@@ -1,0 +1,99 @@
+`timescale 1ns / 1ps
+//=============================================================================
+// Module  : cmd_decoder
+// Purpose : Parse incoming command bytes received from ESP32/PC via uart_rx.
+//
+//  Command format: [0xBC][0xDE][CMD][LEN][DATA×LEN][CS]
+//  CS  = CMD ^ LEN ^ DATA[0..N-1]
+//  Current design supports LEN = 0 or 1 (max 1 payload byte).
+//  cmd_valid pulses for 1 cycle when a valid, checksum-correct command arrives.
+//=============================================================================
+module cmd_decoder (
+    input  logic        clk,
+    input  logic        rst,
+    // uart_rx interface
+    input  logic [7:0]  rx_data,
+    input  logic        rx_done,
+    // decoded command output
+    output logic [7:0]  cmd_out,
+    output logic [7:0]  cmd_payload,
+    output logic        cmd_valid
+);
+
+    typedef enum logic [2:0] {
+        CD_IDLE = 3'd0,
+        CD_HDR2 = 3'd1,
+        CD_CMD  = 3'd2,
+        CD_LEN  = 3'd3,
+        CD_DATA = 3'd4,
+        CD_CS   = 3'd5
+    } cd_state_t;
+
+    cd_state_t  state;
+    logic [7:0] cmd_reg;
+    logic [7:0] len_reg;
+    logic [7:0] data_reg;
+    logic [7:0] cs_calc;
+
+    always_ff @(posedge clk or posedge rst) begin
+        if (rst) begin
+            state       <= CD_IDLE;
+            cmd_out     <= 8'h00;
+            cmd_payload <= 8'h00;
+            cmd_valid   <= 1'b0;
+            cmd_reg     <= 8'h00;
+            len_reg     <= 8'h00;
+            data_reg    <= 8'h00;
+            cs_calc     <= 8'h00;
+        end else begin
+            cmd_valid <= 1'b0;
+
+            if (rx_done) begin
+                case (state)
+                    CD_IDLE: begin
+                        if (rx_data == 8'hBC) state <= CD_HDR2;
+                    end
+
+                    CD_HDR2: begin
+                        if      (rx_data == 8'hDE) state <= CD_CMD;
+                        else if (rx_data == 8'hBC) state <= CD_HDR2;
+                        else                       state <= CD_IDLE;
+                    end
+
+                    CD_CMD: begin
+                        cmd_reg <= rx_data;
+                        cs_calc <= rx_data;
+                        state   <= CD_LEN;
+                    end
+
+                    CD_LEN: begin
+                        len_reg <= rx_data;
+                        cs_calc <= cs_calc ^ rx_data;
+                        if (rx_data == 8'h00)
+                            state <= CD_CS;
+                        else
+                            state <= CD_DATA;
+                    end
+
+                    CD_DATA: begin
+                        data_reg <= rx_data;
+                        cs_calc  <= cs_calc ^ rx_data;
+                        state    <= CD_CS;
+                    end
+
+                    CD_CS: begin
+                        if (rx_data == cs_calc) begin
+                            cmd_out     <= cmd_reg;
+                            cmd_payload <= data_reg;
+                            cmd_valid   <= 1'b1;
+                        end
+                        state <= CD_IDLE;
+                    end
+
+                    default: state <= CD_IDLE;
+                endcase
+            end
+        end
+    end
+
+endmodule

--- a/CNN_RPI_SHT40_uart_packet/sources_1/imports/new/cnn_latch.sv
+++ b/CNN_RPI_SHT40_uart_packet/sources_1/imports/new/cnn_latch.sv
@@ -1,0 +1,34 @@
+`timescale 1ns / 1ps
+//=============================================================================
+// Module  : cnn_latch
+// Purpose : Latch CNN inference result on rising edge of cnn_valid.
+//           Simplified to detect only 'person' status.
+//=============================================================================
+module cnn_latch (
+    input  logic clk,
+    input  logic rst,
+    input  logic cnn_signal,     // 이 신호가 HIGH가 되면 사람 인식으로 판단
+    output logic [7:0] cnn_data, // 항상 8'h01 (사람)로 출력
+    output logic       cnn_event 
+);
+
+    logic signal_prev;
+
+    always_ff @(posedge clk or posedge rst) begin
+        if (rst) begin
+            signal_prev <= 1'b0;
+            cnn_data   <= 8'h00;
+            cnn_event  <= 1'b0;
+        end else begin
+            cnn_event  <= 1'b0;
+            signal_prev <= cnn_signal;
+            
+            // 신호의 상승 에지 감지 시 데이터를 '1'로 고정
+            if (cnn_signal && !signal_prev) begin
+                cnn_data  <= 8'h01; // 신호 발생 = 사람 인식 확정
+                cnn_event <= 1'b1;
+            end
+        end
+    end
+
+endmodule

--- a/CNN_RPI_SHT40_uart_packet/sources_1/imports/new/packet_builder.sv
+++ b/CNN_RPI_SHT40_uart_packet/sources_1/imports/new/packet_builder.sv
@@ -1,0 +1,79 @@
+`timescale 1ns / 1ps
+
+module packet_builder (
+    input  logic        clk,
+    input  logic        rst,
+    // Events
+    input  logic        rpi_event,
+    input  logic        rpi_active,
+    input  logic        cnn_event,
+    input  logic [7:0]  cnn_data,
+    input  logic        sht_event,
+    input  logic [31:0] sht_data,
+    // UART interface
+    input  logic        tx_busy,
+    input  logic        tx_done,
+    output logic        tx_start,
+    output logic [7:0]  tx_byte
+);
+
+    typedef enum logic [3:0] {
+        PB_IDLE, PB_STX1, PB_STX2, PB_TYPE, PB_LEN, PB_PAYLOAD, PB_CS, PB_WAIT
+    } pb_state_t;
+
+    pb_state_t state, next_state;
+    logic [7:0] p_type, p_len, p_cs;
+    logic [7:0] p_payload [0:3];
+    logic [2:0] p_idx;
+
+    // Internal Pending Registers
+    logic r_pend, c_pend, s_pend;
+    logic [7:0] c_data_reg;
+    logic [31:0] s_data_reg;
+
+    always_ff @(posedge clk or posedge rst) begin
+        if (rst) begin
+            state <= PB_IDLE; r_pend <= 0; c_pend <= 0; s_pend <= 0;
+            tx_start <= 0; p_idx <= 0;
+        end else begin
+            tx_start <= 1'b0;
+            if (rpi_event) r_pend <= 1'b1;
+            if (cnn_event) begin c_pend <= 1'b1; c_data_reg <= cnn_data; end
+            if (sht_event) begin s_pend <= 1'b1; s_data_reg <= sht_data; end
+
+            case (state)
+                PB_IDLE: begin
+                    p_idx <= 0;
+                    if (c_pend) begin // CNN Priority 1
+                        p_type <= 8'h02; p_len <= 8'h01; p_payload[0] <= c_data_reg;
+                        p_cs   <= 8'h02 ^ 8'h01 ^ c_data_reg;
+                        c_pend <= 1'b0; state <= PB_STX1;
+                    end else if (r_pend) begin // RPi Priority 2
+                        p_type <= 8'h01; p_len <= 8'h01; p_payload[0] <= 8'h01; // Active status
+                        p_cs   <= 8'h01 ^ 8'h01 ^ 8'h01;
+                        r_pend <= 1'b0; state <= PB_STX1;
+                    end else if (s_pend) begin // SHT40 Priority 3
+                        p_type <= 8'h03; p_len <= 8'h04;
+                        p_payload[0] <= s_data_reg[31:24]; p_payload[1] <= s_data_reg[23:16];
+                        p_payload[2] <= s_data_reg[15:8];  p_payload[3] <= s_data_reg[7:0];
+                        p_cs <= 8'h03 ^ 8'h04 ^ s_data_reg[31:24] ^ s_data_reg[23:16] ^ s_data_reg[15:8] ^ s_data_reg[7:0];
+                        s_pend <= 1'b0; state <= PB_STX1;
+                    end
+                end
+                PB_STX1: if(!tx_busy) begin tx_byte <= 8'hAB; tx_start <= 1; next_state <= PB_STX2; state <= PB_WAIT; end
+                PB_STX2: if(!tx_busy) begin tx_byte <= 8'hCD; tx_start <= 1; next_state <= PB_TYPE; state <= PB_WAIT; end
+                PB_TYPE: if(!tx_busy) begin tx_byte <= p_type; tx_start <= 1; next_state <= PB_LEN; state <= PB_WAIT; end
+                PB_LEN:  if(!tx_busy) begin tx_byte <= p_len;  tx_start <= 1; next_state <= PB_PAYLOAD; state <= PB_WAIT; end
+                PB_PAYLOAD: if(!tx_busy) begin
+                    tx_byte <= p_payload[p_idx]; tx_start <= 1;
+                    if (p_idx == p_len - 1) next_state <= PB_CS;
+                    else begin p_idx <= p_idx + 1; next_state <= PB_PAYLOAD; end
+                    state <= PB_WAIT;
+                end
+                PB_CS:   if(!tx_busy) begin tx_byte <= p_cs; tx_start <= 1; next_state <= PB_IDLE; state <= PB_WAIT; end
+                PB_WAIT: if(tx_done) state <= next_state;
+                default: state <= PB_IDLE;
+            endcase
+        end
+    end
+endmodule

--- a/CNN_RPI_SHT40_uart_packet/sources_1/imports/new/rpi_det.sv
+++ b/CNN_RPI_SHT40_uart_packet/sources_1/imports/new/rpi_det.sv
@@ -1,0 +1,37 @@
+`timescale 1ns / 1ps
+//=============================================================================
+// Module  : rpi_det
+// Purpose : Detect RPi GPIO signal rising edge with 3-stage synchronizer.
+//           Outputs 1-cycle rpi_event only when the signal goes HIGH.
+//=============================================================================
+module rpi_det (
+    input  logic clk,
+    input  logic rst,
+    input  logic rpi_signal,    // async GPIO from RPi
+    output logic rpi_event,     // 1-cycle pulse on posedge
+    output logic rpi_active     // synchronized stable state
+);
+
+    logic d0, d1, d2, d_prev;
+
+    always_ff @(posedge clk or posedge rst) begin
+        if (rst) begin
+            d0         <= 1'b0;
+            d1         <= 1'b0;
+            d2         <= 1'b0;
+            d_prev     <= 1'b0;
+            rpi_active <= 1'b0;
+            rpi_event  <= 1'b0;
+        end else begin
+            d0         <= rpi_signal;
+            d1         <= d0;
+            d2         <= d1;
+            d_prev     <= d2;
+            rpi_active <= d2;
+            
+            // 상승 에지(0 -> 1)만 감지하도록 XOR(^) 대신 AND(&!) 사용
+            rpi_event  <= d2 && !d_prev;
+        end
+    end
+
+endmodule

--- a/CNN_RPI_SHT40_uart_packet/sources_1/imports/new/uart_rx.sv
+++ b/CNN_RPI_SHT40_uart_packet/sources_1/imports/new/uart_rx.sv
@@ -1,0 +1,125 @@
+`timescale 1ns / 1ps
+//=============================================================================
+// Module  : uart_rx
+// Purpose : Deserialize one byte from UART (8N1)
+//           Samples at mid-bit using a 16x oversampled tick
+// Signals : rx_data  - received byte (valid when rx_done pulses)
+//           rx_done  - 1-cycle pulse when full byte received
+//           rx_error - framing error (stop bit not '1')
+//=============================================================================
+module uart_rx #(
+    parameter int CLK_FREQ  = 100_000_000,
+    parameter int BAUD_RATE = 115_200
+)(
+    input  logic       clk,
+    input  logic       rst,
+    input  logic       rx,
+    output logic [7:0] rx_data,
+    output logic       rx_done,
+    output logic       rx_error
+);
+
+    localparam int OVS_DIV = CLK_FREQ / (BAUD_RATE * 16);
+
+    logic [$clog2(OVS_DIV)-1:0] ovs_cnt;
+    logic                        ovs_tick;
+
+    always_ff @(posedge clk or posedge rst) begin
+        if (rst) begin
+            ovs_cnt  <= '0;
+            ovs_tick <= 1'b0;
+        end else if (ovs_cnt == OVS_DIV - 1) begin
+            ovs_cnt  <= '0;
+            ovs_tick <= 1'b1;
+        end else begin
+            ovs_cnt  <= ovs_cnt + 1'b1;
+            ovs_tick <= 1'b0;
+        end
+    end
+
+    typedef enum logic [1:0] {
+        ST_IDLE  = 2'd0,
+        ST_START = 2'd1,
+        ST_DATA  = 2'd2,
+        ST_STOP  = 2'd3
+    } state_t;
+
+    state_t     state;
+    logic [3:0] sample_cnt;
+    logic [2:0] bit_idx;
+    logic [7:0] shift_reg;
+
+    always_ff @(posedge clk or posedge rst) begin
+        if (rst) begin
+            state      <= ST_IDLE;
+            sample_cnt <= '0;
+            bit_idx    <= '0;
+            shift_reg  <= '0;
+            rx_data    <= '0;
+            rx_done    <= 1'b0;
+            rx_error   <= 1'b0;
+        end else begin
+            rx_done  <= 1'b0;
+            rx_error <= 1'b0;
+
+            case (state)
+                ST_IDLE: begin
+                    if (rx == 1'b0) begin
+                        sample_cnt <= '0;
+                        state      <= ST_START;
+                    end
+                end
+
+                ST_START: begin
+                    if (ovs_tick) begin
+                        if (sample_cnt == 4'd7) begin
+                            if (rx == 1'b0) begin
+                                sample_cnt <= '0;
+                                bit_idx    <= '0;
+                                state      <= ST_DATA;
+                            end else begin
+                                state <= ST_IDLE;
+                            end
+                        end else begin
+                            sample_cnt <= sample_cnt + 1'b1;
+                        end
+                    end
+                end
+
+                ST_DATA: begin
+                    if (ovs_tick) begin
+                        if (sample_cnt == 4'd15) begin
+                            sample_cnt <= '0;
+                            shift_reg  <= {rx, shift_reg[7:1]};
+                            if (bit_idx == 3'd7)
+                                state <= ST_STOP;
+                            else
+                                bit_idx <= bit_idx + 1'b1;
+                        end else begin
+                            sample_cnt <= sample_cnt + 1'b1;
+                        end
+                    end
+                end
+
+                ST_STOP: begin
+                    if (ovs_tick) begin
+                        if (sample_cnt == 4'd15) begin
+                            if (rx == 1'b1) begin
+                                rx_data <= shift_reg;
+                                rx_done <= 1'b1;
+                            end else begin
+                                rx_error <= 1'b1;
+                            end
+                            state <= ST_IDLE;
+                        end else begin
+                            sample_cnt <= sample_cnt + 1'b1;
+                        end
+                    end
+                end
+
+                default: state <= ST_IDLE;
+            endcase
+        end
+    end
+
+endmodule

--- a/CNN_RPI_SHT40_uart_packet/sources_1/imports/new/uart_tx.sv
+++ b/CNN_RPI_SHT40_uart_packet/sources_1/imports/new/uart_tx.sv
@@ -1,0 +1,87 @@
+`timescale 1ns / 1ps
+//=============================================================================
+// Module  : uart_tx
+// Purpose : Serialize one byte over UART (8N1)
+// Signals : start  - pulse high for 1 cycle to begin transmission
+//           data   - byte to transmit (sampled on start)
+//           busy   - high while transmitting
+//           done   - 1-cycle pulse when last stop bit is sent
+//           tx     - UART line (idle = 1)
+//=============================================================================
+module uart_tx (
+    input  logic       clk,
+    input  logic       rst,
+    input  logic       baud_tick,
+    input  logic       start,
+    input  logic [7:0] data,
+    output logic       tx,
+    output logic       busy,
+    output logic       done
+);
+
+    typedef enum logic [1:0] {
+        ST_IDLE  = 2'd0,
+        ST_START = 2'd1,
+        ST_DATA  = 2'd2,
+        ST_STOP  = 2'd3
+    } state_t;
+
+    state_t     state;
+    logic [7:0] shift_reg;
+    logic [2:0] bit_idx;
+
+    always_ff @(posedge clk or posedge rst) begin
+        if (rst) begin
+            state     <= ST_IDLE;
+            shift_reg <= '0;
+            bit_idx   <= '0;
+            tx        <= 1'b1;
+            busy      <= 1'b0;
+            done      <= 1'b0;
+        end else begin
+            done <= 1'b0;
+
+            case (state)
+                ST_IDLE: begin
+                    tx   <= 1'b1;
+                    busy <= 1'b0;
+                    if (start) begin
+                        shift_reg <= data;
+                        busy      <= 1'b1;
+                        state     <= ST_START;
+                    end
+                end
+
+                ST_START: begin
+                    if (baud_tick) begin
+                        tx      <= 1'b0;
+                        bit_idx <= 3'd0;
+                        state   <= ST_DATA;
+                    end
+                end
+
+                ST_DATA: begin
+                    if (baud_tick) begin
+                        tx        <= shift_reg[0];
+                        shift_reg <= {1'b0, shift_reg[7:1]};
+                        if (bit_idx == 3'd7)
+                            state <= ST_STOP;
+                        else
+                            bit_idx <= bit_idx + 1'b1;
+                    end
+                end
+
+                ST_STOP: begin
+                    if (baud_tick) begin
+                        tx    <= 1'b1;
+                        done  <= 1'b1;
+                        state <= ST_IDLE;
+                    end
+                end
+
+                default: state <= ST_IDLE;
+            endcase
+        end
+    end
+
+endmodule

--- a/CNN_RPI_SHT40_uart_packet/sources_1/new/sht40_i2c.sv
+++ b/CNN_RPI_SHT40_uart_packet/sources_1/new/sht40_i2c.sv
@@ -1,0 +1,323 @@
+`timescale 1ns / 1ps
+
+module sht40_i2c #(
+    parameter int CLK_FREQ = 100_000_000
+)(
+    input  logic        clk,
+    input  logic        rst,
+    inout  wire         i2c_sda,
+    output logic        i2c_scl,
+    output logic [31:0] sht_data,  // {Temp_MSB, Temp_LSB, Hum_MSB, Hum_LSB}
+    output logic        sht_valid
+);
+    // ─── 타이머 (1초 주기 트리거) ──────────────────────────────────────────
+    localparam int TIMER_1SEC  = CLK_FREQ;
+    //localparam int WAIT_10MS   = CLK_FREQ / 100;   // 10ms
+    localparam int WAIT_10MS   = 400_000 / 100;           // 4_000 (phase_tick 기준, 10ms 정확)
+
+    logic [31:0] sec_cnt;
+    logic        trigger_read;
+
+    always_ff @(posedge clk or posedge rst) begin
+        if (rst) begin
+            sec_cnt      <= '0;
+            trigger_read <= 1'b0;
+        end else begin
+            trigger_read <= 1'b0;
+            if (sec_cnt == TIMER_1SEC - 1) begin
+                sec_cnt      <= '0;
+                trigger_read <= 1'b1;
+            end else
+                sec_cnt <= sec_cnt + 1;
+        end
+    end
+
+    // ─── I2C SCL 클럭 분주 (100 kHz) ──────────────────────────────────────
+    // SCL 1주기 = 4 phase: PULL_LOW → LOW_HOLD → RELEASE → HIGH_HOLD
+    localparam int PHASE_DIV = CLK_FREQ / 400_000; // 각 phase 길이
+
+    logic [$clog2(PHASE_DIV)-1:0] phase_cnt;
+    logic                          phase_tick;
+
+    always_ff @(posedge clk or posedge rst) begin
+        if (rst) begin
+            phase_cnt  <= '0;
+            phase_tick <= 1'b0;
+        end else begin
+            phase_tick <= 1'b0;
+            if (phase_cnt == PHASE_DIV - 1) begin
+                phase_cnt  <= '0;
+                phase_tick <= 1'b1;
+            end else
+                phase_cnt <= phase_cnt + 1;
+        end
+    end
+
+    // ─── FSM 상태 (localparam, typedef enum 사용 금지) ─────────────────────
+    localparam logic [3:0]
+        S_IDLE        = 4'd0,
+        S_START       = 4'd1,
+        S_TX_BYTE     = 4'd2,
+        S_ACK_W       = 4'd3,
+        S_WAIT_MEAS   = 4'd4,
+        S_RESTART     = 4'd5,
+        S_TX_ADDR_R   = 4'd6,
+        S_ACK_R       = 4'd7,
+        S_RX_BYTE     = 4'd8,
+        S_SEND_ACK    = 4'd9,
+        S_SEND_NACK   = 4'd10,
+        S_STOP        = 4'd11,
+        S_DONE        = 4'd12;
+
+    // SHT40 I2C 주소 0x44, R=1 / W=0
+    localparam logic [7:0] ADDR_W = 8'h88; // 0x44<<1 | 0
+    localparam logic [7:0] ADDR_R = 8'h89; // 0x44<<1 | 1
+    localparam logic [7:0] CMD_HP = 8'hFD; // 고정밀 측정 명령
+
+    logic [3:0]  state;
+    logic [2:0]  bit_idx;       // 현재 전송/수신 비트 (7→0)
+    logic [3:0]  rx_cnt;        // 수신한 바이트 수
+    logic [2:0]  phase;         // SCL 4-phase 카운터 (0~3)
+    logic [7:0]  tx_byte;
+    logic [7:0]  rx_byte;
+    logic [31:0] wait_cnt;
+
+    // SDA open-drain 
+    logic sda_out;
+    logic sda_oe;               // 1=드라이브, 0=Hi-Z
+    // IOBUF 명시적 인스턴스로 교체
+    // I2C open-drain: 드라이브할 때는 항상 LOW(I=0), T=0이면 출력, T=1이면 Hi-Z
+    logic sda_in;
+    wire  sda_drive = sda_oe & ~sda_out;  // 실제로 LOW를 구동해야 할 때만 1
+
+    IOBUF sda_iobuf (
+        .IO(i2c_sda),       // 물리 핀
+        .I (1'b0),          // 출력값은 항상 0 (open-drain이므로)
+        .O (sda_in),        // 핀에서 읽은 값
+        .T (~sda_drive)     // T=0이면 드라이브, T=1이면 Hi-Z
+    );
+
+    // 수신 버퍼: T_H, T_L, CRC_T, H_H, H_L, CRC_H (6바이트)
+    logic [7:0] rx_buf [0:5];
+
+    always_ff @(posedge clk or posedge rst) begin
+        if (rst) begin
+            state     <= S_IDLE;
+            i2c_scl   <= 1'b1;
+            sda_out   <= 1'b1;
+            sda_oe    <= 1'b1;
+            sht_valid <= 1'b0;
+            sht_data  <= '0;
+            wait_cnt  <= '0;
+            rx_cnt    <= '0;
+            phase     <= '0;
+        end else begin
+            sht_valid <= 1'b0;
+
+            if (phase_tick) begin
+                case (state)
+
+                    // ── IDLE ──────────────────────────────────────────────
+                    S_IDLE: begin
+                        i2c_scl <= 1'b1;
+                        sda_out <= 1'b1; sda_oe <= 1'b1;
+                        if (trigger_read) begin
+                            state <= S_START;
+                            phase <= 0;
+                        end
+                    end
+
+                    // ── START condition: SDA 1→0 while SCL=1 ─────────────
+                    S_START: begin
+                        case (phase)
+                            0: begin i2c_scl<=1; sda_out<=1; sda_oe<=1; phase<=1; end
+                            1: begin sda_out<=0; phase<=2; end
+                            2: begin i2c_scl<=0; phase<=3; end
+                            3: begin
+                                tx_byte <= ADDR_W;
+                                bit_idx <= 7;
+                                state   <= S_TX_BYTE;
+                                phase   <= 0;
+                            end
+                        endcase
+                    end
+
+                    // ── TX_BYTE: MSB first ────────────────────────────────
+                    S_TX_BYTE: begin
+                        case (phase)
+                            0: begin
+                                sda_out <= tx_byte[bit_idx];
+                                sda_oe  <= 1'b1;
+                                i2c_scl <= 0;
+                                phase   <= 1;
+                            end
+                            1: begin i2c_scl <= 1; phase <= 2; end
+                            2: begin phase <= 3; end
+                            3: begin
+                                i2c_scl <= 0;
+                                if (bit_idx == 0) begin
+                                    phase <= 0;
+                                    // 어떤 바이트를 보냈는지에 따라 다음 상태 결정
+                                    if (tx_byte == ADDR_W) begin
+                                        state <= S_ACK_W;
+                                        // ACK 후 CMD 전송
+                                    end else if (tx_byte == CMD_HP) begin
+                                        state <= S_ACK_W;
+                                    end else if (tx_byte == ADDR_R) begin
+                                        state <= S_ACK_R;
+                                    end
+                                end else begin
+                                    bit_idx <= bit_idx - 1;
+                                    phase   <= 0;
+                                end
+                            end
+                        endcase
+                    end
+
+                    // ── ACK 수신 (쓰기 후) ────────────────────────────────
+                    S_ACK_W: begin
+                        case (phase)
+                            0: begin sda_oe<=0; i2c_scl<=0; phase<=1; end
+                            1: begin i2c_scl<=1; phase<=2; end
+                            2: begin phase<=3; end  // ACK 샘플 (무시)
+                            3: begin
+                                i2c_scl <= 0;
+                                phase   <= 0;
+                                // ADDR_W ACK → CMD 전송
+                                if (tx_byte == ADDR_W) begin
+                                    tx_byte <= CMD_HP;
+                                    bit_idx <= 7;
+                                    state   <= S_TX_BYTE;
+                                end else begin
+                                    // CMD ACK → 10ms 대기
+                                    wait_cnt <= 0;
+                                    state    <= S_WAIT_MEAS;
+                                end
+                            end
+                        endcase
+                    end
+
+                    // ── 10ms 측정 대기 ────────────────────────────────────
+                    S_WAIT_MEAS: begin
+                        wait_cnt <= wait_cnt + 1;
+                        if (wait_cnt == WAIT_10MS - 1) begin
+                            wait_cnt <= 0;
+                            state    <= S_RESTART;
+                            phase    <= 0;
+                        end
+                    end
+
+                    // ── RESTART condition ─────────────────────────────────
+                    S_RESTART: begin
+                        case (phase)
+                            0: begin sda_out<=1; sda_oe<=1; i2c_scl<=0; phase<=1; end
+                            1: begin i2c_scl<=1; phase<=2; end
+                            2: begin sda_out<=0; phase<=3; end
+                            3: begin
+                                i2c_scl <= 0;
+                                tx_byte <= ADDR_R;
+                                bit_idx <= 7;
+                                state   <= S_TX_BYTE;
+                                phase   <= 0;
+                            end
+                        endcase
+                    end
+
+                    // ── ACK 수신 (읽기 주소 후) ───────────────────────────
+                    S_ACK_R: begin
+                        case (phase)
+                            0: begin sda_oe<=0; i2c_scl<=0; phase<=1; end
+                            1: begin i2c_scl<=1; phase<=2; end
+                            2: begin phase<=3; end
+                            3: begin
+                                i2c_scl <= 0;
+                                bit_idx <= 7;
+                                rx_cnt  <= 0;
+                                state   <= S_RX_BYTE;
+                                phase   <= 0;
+                            end
+                        endcase
+                    end
+
+                    // ── RX_BYTE ───────────────────────────────────────────
+                    S_RX_BYTE: begin
+                        case (phase)
+                            0: begin sda_oe<=0; i2c_scl<=0; phase<=1; end
+                            1: begin i2c_scl<=1; phase<=2; end
+                            2: begin
+                                rx_byte[bit_idx] <= sda_in;
+                                phase <= 3;
+                            end
+                            3: begin
+                                i2c_scl <= 0;
+                                if (bit_idx == 0) begin
+                                    rx_buf[rx_cnt] <= rx_byte;
+                                    phase <= 0;
+                                    // 5번째 바이트(인덱스 4=H_L)까지 ACK, 마지막(5=CRC_H)은 NACK
+                                    if (rx_cnt == 5) begin
+                                        state <= S_SEND_NACK;
+                                    end else begin
+                                        state <= S_SEND_ACK;
+                                    end
+                                end else begin
+                                    bit_idx <= bit_idx - 1;
+                                    phase   <= 0;
+                                end
+                            end
+                        endcase
+                    end
+
+                    // ── ACK 전송 (마스터→슬레이브) ───────────────────────
+                    S_SEND_ACK: begin
+                        case (phase)
+                            0: begin sda_out<=0; sda_oe<=1; i2c_scl<=0; phase<=1; end
+                            1: begin i2c_scl<=1; phase<=2; end
+                            2: begin phase<=3; end
+                            3: begin
+                                i2c_scl <= 0;
+                                rx_cnt  <= rx_cnt + 1;
+                                bit_idx <= 7;
+                                state   <= S_RX_BYTE;
+                                phase   <= 0;
+                            end
+                        endcase
+                    end
+
+                    // ── NACK 전송 (마지막 바이트 후) ─────────────────────
+                    S_SEND_NACK: begin
+                        case (phase)
+                            0: begin sda_out<=1; sda_oe<=1; i2c_scl<=0; phase<=1; end
+                            1: begin i2c_scl<=1; phase<=2; end
+                            2: begin phase<=3; end
+                            3: begin
+                                i2c_scl <= 0;
+                                state   <= S_STOP;
+                                phase   <= 0;
+                            end
+                        endcase
+                    end
+
+                    // ── STOP condition: SDA 0→1 while SCL=1 ──────────────
+                    S_STOP: begin
+                        case (phase)
+                            0: begin sda_out<=0; sda_oe<=1; i2c_scl<=0; phase<=1; end
+                            1: begin i2c_scl<=1; phase<=2; end
+                            2: begin sda_out<=1; phase<=3; end
+                            3: begin state<=S_DONE; phase<=0; end
+                        endcase
+                    end
+
+                    // ── DONE: 수신 데이터 출력 ────────────────────────────
+                    // rx_buf: [0]=T_H [1]=T_L [2]=CRC_T [3]=H_H [4]=H_L [5]=CRC_H
+                    S_DONE: begin
+                        sht_data  <= {rx_buf[0], rx_buf[1], rx_buf[3], rx_buf[4]};
+                        sht_valid <= 1'b1;
+                        state     <= S_IDLE;
+                    end
+
+                    default: state <= S_IDLE;
+                endcase
+            end
+        end
+    end
+endmodule

--- a/PC_python/README.md
+++ b/PC_python/README.md
@@ -1,0 +1,21 @@
+# PC Receiver Script (Python)
+
+ESP32 Receiver로부터 들어오는 로그 데이터를 실시간으로 파싱하고 출력하는 테스트용 스크립트입니다.
+
+## 파일 정보
+- `pc_receiver_esp32.py`: 메인 실행 스크립트
+
+## 기능
+- **패킷 파싱**: 0xEF, 0xBE 매직 넘버를 기반으로 패킷의 시작을 감지합니다.
+- **채널 구분**:
+  - `CHAN 0x01`: Lidar 데이터 (YDLiDAR X4PRO)
+  - `CHAN 0x02`: FPGA 보드 데이터 (RPi/CNN/SHT40)
+- **로그 출력**: 수신된 데이터를 터미널에 가독성 있는 형식으로 출력합니다.
+
+## 실행 방법
+```bash
+# 기본 실행 (포트: COM3, 보레이트: 460800)
+python pc_receiver_esp32.py
+
+# 특정 포트 지정 실행
+python pc_receiver_esp32.py COM15 460800

--- a/PC_python/pc_receiver_esp32.py
+++ b/PC_python/pc_receiver_esp32.py
@@ -1,0 +1,230 @@
+#!/usr/bin/env python3
+"""
+pc_receiver_esp32.py
+  PC ← USB/UART(460800) ← ESP32 #2 ← WiFi ← ESP32 #1 ← LiDAR / FPGA
+
+  CHAN=0x01 : YDLiDAR X4PRO scan packets  → [LIDAR] FSA / LSA / hex dump
+  CHAN=0x02 : FPGA board packets           → [FPGA]  RPi / CNN / SHT40
+
+Usage:
+  python pc_receiver_esp32.py [PORT] [BAUD]
+
+  Windows  기본 PORT : COM3
+  Linux    기본 PORT : /dev/ttyUSB0
+  기본 BAUD : 460800
+"""
+
+import sys
+import struct
+import serial          # pip install pyserial
+
+# ─── 기본 설정 ────────────────────────────────────────────────────────────────
+DEFAULT_PORT = "COM3"           # Linux: "/dev/ttyUSB0"
+DEFAULT_BAUD = 460800
+
+# ─── TCP 래퍼 상수 (ESP32 와 동일) ───────────────────────────────────────────
+MAGIC1          = 0xEF
+MAGIC2          = 0xBE
+CHAN_LIDAR      = 0x01
+CHAN_BOARD      = 0x02
+
+# ─── FPGA 패킷 상수 ──────────────────────────────────────────────────────────
+BOARD_STX1      = 0xAB
+BOARD_STX2      = 0xCD
+TYPE_RPI        = 0x01
+TYPE_CNN        = 0x02
+TYPE_SHT        = 0x03
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# LiDAR 패킷 파서 (X4PRO 개발 매뉴얼 §5 기준)
+# ─────────────────────────────────────────────────────────────────────────────
+class LidarParser:
+    def __init__(self):
+        self.buf = bytearray()
+
+    def feed(self, data: bytes):
+        self.buf.extend(data)
+        while self._try_parse():
+            pass
+
+    def _try_parse(self) -> bool:
+        # PH = 0x55 0xAA 동기화
+        while len(self.buf) >= 2:
+            if self.buf[0] == 0x55 and self.buf[1] == 0xAA:
+                break
+            self.buf.pop(0)
+
+        if len(self.buf) < 10:
+            return False
+
+        lsn     = self.buf[3]
+        pkt_len = 10 + 2 * lsn
+
+        if len(self.buf) < pkt_len:
+            return False
+
+        pkt = bytes(self.buf[:pkt_len])
+        del self.buf[:pkt_len]
+
+        ct      = pkt[2]
+        fsa_raw = struct.unpack_from('<H', pkt, 4)[0]
+        lsa_raw = struct.unpack_from('<H', pkt, 6)[0]
+
+        # 1차 각도 계산 (매뉴얼 §5.4)
+        angle_fsa = (fsa_raw >> 1) / 64.0
+        angle_lsa = (lsa_raw >> 1) / 64.0
+        is_start  = bool(ct & 0x01)
+
+        hex_str = ' '.join(f'{b:02X}' for b in pkt)
+        if is_start:
+            print()
+        print(f"[LIDAR]{'[START]' if is_start else '       '} "
+              f"FSA={angle_fsa:6.2f}° LSA={angle_lsa:6.2f}° LSN={lsn:3d} | {hex_str}")
+        return True
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# FPGA 보드 패킷 파서
+# 패킷: [0xAB][0xCD][TYPE][LEN][PAYLOAD...][XOR_CS]
+# ─────────────────────────────────────────────────────────────────────────────
+class BoardParser:
+    def __init__(self):
+        self.buf = bytearray()
+
+    def feed(self, data: bytes):
+        self.buf.extend(data)
+        while self._try_parse():
+            pass
+
+    def _try_parse(self) -> bool:
+        # STX 동기화
+        while len(self.buf) >= 2:
+            if self.buf[0] == BOARD_STX1 and self.buf[1] == BOARD_STX2:
+                break
+            self.buf.pop(0)
+
+        if len(self.buf) < 4:
+            return False
+
+        ptype = self.buf[2]
+        plen  = self.buf[3]
+        total = 4 + plen + 1   # header(4) + payload + CS(1)
+
+        if len(self.buf) < total:
+            return False
+
+        payload  = bytes(self.buf[4 : 4 + plen])
+        cs_recv  = self.buf[4 + plen]
+        del self.buf[:total]
+
+        cs_calc = ptype ^ plen
+        for b in payload:
+            cs_calc ^= b
+
+        if cs_calc != cs_recv:
+            print(f"[FPGA] CS ERROR  type=0x{ptype:02X} "
+                  f"expected=0x{cs_calc:02X} got=0x{cs_recv:02X}")
+            return True
+
+        self._dispatch(ptype, payload)
+        return True
+
+    def _dispatch(self, ptype: int, payload: bytes):
+        if ptype == TYPE_RPI:
+            print("[FPGA] RPi:   *** RESCUE SIGNAL DETECTED ***")
+
+        elif ptype == TYPE_CNN:
+            if payload:
+                person = bool(payload[0] & 0x01)
+                print(f"[FPGA] CNN:   person={'YES' if person else 'NO '}  "
+                      f"(raw=0x{payload[0]:02X})")
+
+        elif ptype == TYPE_SHT:
+            if len(payload) >= 4:
+                raw_t = struct.unpack_from('>H', payload, 0)[0]
+                raw_h = struct.unpack_from('>H', payload, 2)[0]
+                temp  = -45.0 + 175.0 * raw_t / 65535.0
+                humi  = max(0.0, min(100.0, -6.0 + 125.0 * raw_h / 65535.0))
+                print(f"[FPGA] SHT40: Temp={temp:5.1f}°C  Humidity={humi:4.1f}%")
+
+        else:
+            hex_str = ' '.join(f'{b:02X}' for b in payload)
+            print(f"[FPGA] Unknown type=0x{ptype:02X}  payload={hex_str}")
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# 메인: Serial 포트 열기 → 래퍼 FSM 파싱 → 채널별 파서 위임
+# ─────────────────────────────────────────────────────────────────────────────
+def run(port: str, baud: int):
+    # timeout=0 : non-blocking read, 데이터 없으면 빈 bytes 반환
+    # 빠른 폴링으로 지연 최소화
+    ser = serial.Serial(port, baud, bytesize=8, parity='N',
+                        stopbits=1, timeout=0.02)
+
+    print(f"[System] Serial receiver: {port} @ {baud} baud")
+    print(f"         ESP32 #2 연결 대기 중...\n")
+
+    lidar_p = LidarParser()
+    board_p = BoardParser()
+
+    state  = "MAGIC1"
+    chan   = 0
+    length = 0
+    cnt    = 0
+    pbuf   = bytearray()
+
+    while True:
+        chunk = ser.read(4096)
+        if not chunk:
+            continue
+
+        for b in chunk:
+            if state == "MAGIC1":
+                if b == MAGIC1:
+                    state = "MAGIC2"
+
+            elif state == "MAGIC2":
+                if   b == MAGIC2: state = "CHAN"
+                elif b == MAGIC1: state = "MAGIC2"
+                else:             state = "MAGIC1"
+
+            elif state == "CHAN":
+                chan  = b
+                state = "LEN_L"
+
+            elif state == "LEN_L":
+                length = b
+                state  = "LEN_H"
+
+            elif state == "LEN_H":
+                length |= (b << 8)
+                cnt = 0
+                pbuf.clear()
+                state = "PAYLOAD" if length > 0 else "MAGIC1"
+
+            elif state == "PAYLOAD":
+                pbuf.append(b)
+                cnt += 1
+                if cnt == length:
+                    payload = bytes(pbuf)
+                    if   chan == CHAN_LIDAR: lidar_p.feed(payload)
+                    elif chan == CHAN_BOARD: board_p.feed(payload)
+                    state = "MAGIC1"
+
+
+def main():
+    port = sys.argv[1] if len(sys.argv) > 1 else DEFAULT_PORT
+    baud = int(sys.argv[2]) if len(sys.argv) > 2 else DEFAULT_BAUD
+
+    try:
+        run(port, baud)
+    except serial.SerialException as e:
+        print(f"[ERROR] 포트 열기 실패: {e}")
+        print("  사용 가능 포트 확인: python -m serial.tools.list_ports")
+    except KeyboardInterrupt:
+        print("\n[System] 종료.")
+
+
+if __name__ == "__main__":
+    main()

--- a/wifi/esp32_receiver/0420_esp_to_esp_to_pc_01/.gitignore
+++ b/wifi/esp32_receiver/0420_esp_to_esp_to_pc_01/.gitignore
@@ -1,0 +1,5 @@
+.pio
+.vscode/.browse.c_cpp.db*
+.vscode/c_cpp_properties.json
+.vscode/launch.json
+.vscode/ipch

--- a/wifi/esp32_receiver/0420_esp_to_esp_to_pc_01/include/README
+++ b/wifi/esp32_receiver/0420_esp_to_esp_to_pc_01/include/README
@@ -1,0 +1,37 @@
+
+This directory is intended for project header files.
+
+A header file is a file containing C declarations and macro definitions
+to be shared between several project source files. You request the use of a
+header file in your project source file (C, C++, etc) located in `src` folder
+by including it, with the C preprocessing directive `#include'.
+
+```src/main.c
+
+#include "header.h"
+
+int main (void)
+{
+ ...
+}
+```
+
+Including a header file produces the same results as copying the header file
+into each source file that needs it. Such copying would be time-consuming
+and error-prone. With a header file, the related declarations appear
+in only one place. If they need to be changed, they can be changed in one
+place, and programs that include the header file will automatically use the
+new version when next recompiled. The header file eliminates the labor of
+finding and changing all the copies as well as the risk that a failure to
+find one copy will result in inconsistencies within a program.
+
+In C, the convention is to give header files names that end with `.h'.
+
+Read more about using header files in official GCC documentation:
+
+* Include Syntax
+* Include Operation
+* Once-Only Headers
+* Computed Includes
+
+https://gcc.gnu.org/onlinedocs/cpp/Header-Files.html

--- a/wifi/esp32_receiver/0420_esp_to_esp_to_pc_01/include/config.h
+++ b/wifi/esp32_receiver/0420_esp_to_esp_to_pc_01/include/config.h
@@ -1,0 +1,37 @@
+#pragma once
+#include <cstdint>
+
+// ─── WiFi SoftAP ──────────────────────────────────────────────────────────────
+// ESP32 #1 이 이 AP 에 연결함 (공유기 우회)
+// AP 기본 게이트웨이: 192.168.4.1  ← ESP32 #1 의 PC_IP 와 일치해야 함
+#define AP_SSID             "ESP32_BRIDGE_AP"
+#define AP_PASSWORD         "bridge1234"       // 최소 8자
+#define AP_CHANNEL          6
+#define AP_MAX_CLIENTS      1                  // ESP32 #1 단독 연결
+
+// ─── TCP Server ───────────────────────────────────────────────────────────────
+#define TCP_PORT            8888
+
+// ─── PC 데이터 UART (Serial / UART0 / USB-CDC) ────────────────────────────────
+// LiDAR raw ≈ 12.8 kB/s + 프레이밍 오버헤드 → 460800 baud = 약 3.5× 여유
+#define PC_UART_BAUD        460800
+#define PC_UART_TX_BUF      8192               // Serial TX 소프트웨어 버퍼
+
+// ─── 디버그 UART (Serial2 / GPIO16=RX, GPIO17=TX) ────────────────────────────
+// 데이터 스트림과 완전 분리. USB-UART 어댑터로 별도 모니터링 (선택)
+#define DBG_UART_BAUD       115200
+#define DBG_RX_PIN          16
+#define DBG_TX_PIN          17
+
+// ─── Status LED ───────────────────────────────────────────────────────────────
+#define STATUS_LED_PIN      2                  // 대부분의 ESP32 DevKit 내장 LED
+
+// ─── TCP Framing (ESP32 #1 과 동일) ───────────────────────────────────────────
+#define TCP_MAGIC_1         0xEFu
+#define TCP_MAGIC_2         0xBEu
+#define CHAN_LIDAR          0x01u
+#define CHAN_BOARD          0x02u
+#define CHAN_CMD_TO_BOARD   0x03u
+
+// ─── 릴레이 버퍼 ─────────────────────────────────────────────────────────────
+#define FWD_BUF_SIZE        2048u

--- a/wifi/esp32_receiver/0420_esp_to_esp_to_pc_01/include/tcp_rx_task.h
+++ b/wifi/esp32_receiver/0420_esp_to_esp_to_pc_01/include/tcp_rx_task.h
@@ -1,0 +1,4 @@
+#pragma once
+
+// Core 0: ESP32 #1 로부터 TCP 수신 → Serial(UART0) 릴레이
+void tcpForwardTask(void* pvParameters);

--- a/wifi/esp32_receiver/0420_esp_to_esp_to_pc_01/include/wifi_server.h
+++ b/wifi/esp32_receiver/0420_esp_to_esp_to_pc_01/include/wifi_server.h
@@ -1,0 +1,7 @@
+#pragma once
+#include <WiFi.h>
+
+extern WiFiServer tcpServer;
+
+// SoftAP 시작 + TCP 서버 바인드
+void startAP();

--- a/wifi/esp32_receiver/0420_esp_to_esp_to_pc_01/lib/README
+++ b/wifi/esp32_receiver/0420_esp_to_esp_to_pc_01/lib/README
@@ -1,0 +1,46 @@
+
+This directory is intended for project specific (private) libraries.
+PlatformIO will compile them to static libraries and link into the executable file.
+
+The source code of each library should be placed in a separate directory
+("lib/your_library_name/[Code]").
+
+For example, see the structure of the following example libraries `Foo` and `Bar`:
+
+|--lib
+|  |
+|  |--Bar
+|  |  |--docs
+|  |  |--examples
+|  |  |--src
+|  |     |- Bar.c
+|  |     |- Bar.h
+|  |  |- library.json (optional. for custom build options, etc) https://docs.platformio.org/page/librarymanager/config.html
+|  |
+|  |--Foo
+|  |  |- Foo.c
+|  |  |- Foo.h
+|  |
+|  |- README --> THIS FILE
+|
+|- platformio.ini
+|--src
+   |- main.c
+
+Example contents of `src/main.c` using Foo and Bar:
+```
+#include <Foo.h>
+#include <Bar.h>
+
+int main (void)
+{
+  ...
+}
+
+```
+
+The PlatformIO Library Dependency Finder will find automatically dependent
+libraries by scanning project source files.
+
+More information about PlatformIO Library Dependency Finder
+- https://docs.platformio.org/page/librarymanager/ldf.html

--- a/wifi/esp32_receiver/0420_esp_to_esp_to_pc_01/src/main.cpp
+++ b/wifi/esp32_receiver/0420_esp_to_esp_to_pc_01/src/main.cpp
@@ -1,0 +1,35 @@
+#include <Arduino.h>
+#include <WiFi.h>
+#include <freertos/FreeRTOS.h>
+#include <freertos/task.h>
+
+#include "config.h"
+#include "wifi_server.h"
+#include "tcp_rx_task.h"
+
+void setup() {
+    // ── 데이터 UART (UART0 / USB) ─────────────────────────────────────────────
+    // 이 시리얼에는 디버그 출력 일절 금지 — PC 파서가 raw 프레임 스트림으로 읽음
+    Serial.setTxBufferSize(PC_UART_TX_BUF);
+    Serial.begin(PC_UART_BAUD);
+
+    // ── 디버그 UART (UART2 / GPIO16=RX, GPIO17=TX) ────────────────────────────
+    Serial2.begin(DBG_UART_BAUD, SERIAL_8N1, DBG_RX_PIN, DBG_TX_PIN);
+    Serial2.println("\n[System] ESP32 Receiver Bridge v1.0");
+    Serial2.printf("[System] Data UART0 @ %d baud\n", PC_UART_BAUD);
+
+    // ── Status LED ────────────────────────────────────────────────────────────
+    pinMode(STATUS_LED_PIN, OUTPUT);
+    digitalWrite(STATUS_LED_PIN, LOW);
+
+    // ── SoftAP + TCP 서버 시작 ────────────────────────────────────────────────
+    startAP();
+
+    // ── 포워딩 태스크 (Core 0) ────────────────────────────────────────────────
+    xTaskCreatePinnedToCore(tcpForwardTask, "TCP_FWD", 8192, NULL, 5, NULL, 0);
+    Serial2.println("[System] tcpForwardTask launched. Waiting for ESP32 #1...");
+}
+
+void loop() {
+    vTaskDelay(pdMS_TO_TICKS(1000));
+}

--- a/wifi/esp32_receiver/0420_esp_to_esp_to_pc_01/src/tcp_rx_task.cpp
+++ b/wifi/esp32_receiver/0420_esp_to_esp_to_pc_01/src/tcp_rx_task.cpp
@@ -1,0 +1,106 @@
+#include "tcp_rx_task.h"
+#include "wifi_server.h"
+#include "config.h"
+#include <Arduino.h>
+#include <freertos/FreeRTOS.h>
+#include <freertos/task.h>
+
+static uint8_t fwdBuf[FWD_BUF_SIZE];
+
+void tcpForwardTask(void* /*pv*/) {
+    Serial2.printf("[FWD] Task on Core %d\n", xPortGetCoreID());
+
+    while (true) {
+        WiFiClient client = tcpServer.available();
+        if (!client) {
+            vTaskDelay(pdMS_TO_TICKS(10));
+            continue;
+        }
+
+        client.setNoDelay(true);
+        Serial2.printf("[FWD] Connected: %s\n",
+                       client.remoteIP().toString().c_str());
+        digitalWrite(STATUS_LED_PIN, HIGH);
+
+        // 재연결 시 Serial TX 버퍼 잔여물 제거
+        Serial.flush();
+
+        while (client.connected()) {
+            int avail = client.available();
+            if (avail > 0) {
+                int n = client.read(fwdBuf,
+                            min(avail, static_cast<int>(FWD_BUF_SIZE)));
+                if (n > 0) {
+                    // TX 버퍼 여유 확인 후 write — 블로킹 방지
+                    int writable = Serial.availableForWrite();
+                    if (writable >= n) {
+                        Serial.write(fwdBuf, static_cast<size_t>(n));
+                    } else if (writable > 0) {
+                        // 쓸 수 있는 만큼만 write, 나머지는 드롭
+                        // LiDAR 스트림 특성상 일부 드롭이 전체 블로킹보다 낫습니다
+                        Serial.write(fwdBuf, static_cast<size_t>(writable));
+                    }
+                    // writable == 0: 이번 청크 드롭, 다음 루프에서 재시도
+                }
+            } else {
+                vTaskDelay(pdMS_TO_TICKS(1));
+            }
+        }
+
+        client.stop();
+        digitalWrite(STATUS_LED_PIN, LOW);
+        Serial2.println("[FWD] Client disconnected");
+        vTaskDelay(pdMS_TO_TICKS(500));
+    }
+}
+
+// #include "tcp_rx_task.h"
+// #include "wifi_server.h"
+// #include "config.h"
+// #include <Arduino.h>
+// #include <freertos/FreeRTOS.h>
+// #include <freertos/task.h>
+
+// static uint8_t fwdBuf[FWD_BUF_SIZE];
+
+// void tcpForwardTask(void* /*pv*/) {
+//     Serial2.printf("[FWD] Task on Core %d\n", xPortGetCoreID());
+
+//     while (true) {
+//         // ── 클라이언트 연결 대기 ──────────────────────────────────────────────
+//         WiFiClient client = tcpServer.available();
+//         if (!client) {
+//             vTaskDelay(pdMS_TO_TICKS(10));
+//             continue;
+//         }
+
+//         // Nagle 비활성화: 소형 패킷 지연 방지
+//         client.setNoDelay(true);
+
+//         Serial2.printf("[FWD] Connected: %s\n",
+//                        client.remoteIP().toString().c_str());
+//         digitalWrite(STATUS_LED_PIN, HIGH);
+
+//         // ── 릴레이 루프 ───────────────────────────────────────────────────────
+//         // 파싱 없이 수신 바이트를 Serial(PC) 로 그대로 전달.
+//         // 프레이밍(0xEF 0xBE + 채널 + 길이 + 페이로드)은 ESP32 #1 이 보장.
+//         while (client.connected()) {
+//             int avail = client.available();
+//             if (avail > 0) {
+//                 int n = client.read(fwdBuf,
+//                             min(avail, static_cast<int>(FWD_BUF_SIZE)));
+//                 if (n > 0) {
+//                     Serial.write(fwdBuf, static_cast<size_t>(n));
+//                 }
+//             } else {
+//                 vTaskDelay(pdMS_TO_TICKS(1));
+//             }
+//         }
+
+//         // ── 연결 종료 ─────────────────────────────────────────────────────────
+//         client.stop();
+//         digitalWrite(STATUS_LED_PIN, LOW);
+//         Serial2.println("[FWD] Client disconnected — waiting for reconnect");
+//         vTaskDelay(pdMS_TO_TICKS(500)); // ← 소켓 정리 대기
+//     }
+// }

--- a/wifi/esp32_receiver/0420_esp_to_esp_to_pc_01/src/wifi_server.cpp
+++ b/wifi/esp32_receiver/0420_esp_to_esp_to_pc_01/src/wifi_server.cpp
@@ -1,0 +1,22 @@
+#include "wifi_server.h"
+#include "config.h"
+#include <Arduino.h>
+
+WiFiServer tcpServer(TCP_PORT);
+
+void startAP() {
+    WiFi.mode(WIFI_AP);
+    // channel, hidden=false, max_connection=1
+    bool ok = WiFi.softAP(AP_SSID, AP_PASSWORD, AP_CHANNEL, 0, AP_MAX_CLIENTS);
+    if (!ok) {
+        Serial2.println("[AP] softAP() failed — check password length (>=8)");
+    } else {
+        Serial2.printf("[AP] SSID=%s  GW=%s\n",
+                       AP_SSID,
+                       WiFi.softAPIP().toString().c_str());
+    }
+
+    tcpServer.begin();
+    tcpServer.setNoDelay(true);
+    Serial2.printf("[TCP] Server listening on port %d\n", TCP_PORT);
+}

--- a/wifi/esp32_receiver/0420_esp_to_esp_to_pc_01/test/README
+++ b/wifi/esp32_receiver/0420_esp_to_esp_to_pc_01/test/README
@@ -1,0 +1,11 @@
+
+This directory is intended for PlatformIO Test Runner and project tests.
+
+Unit Testing is a software testing method by which individual units of
+source code, sets of one or more MCU program modules together with associated
+control data, usage procedures, and operating procedures, are tested to
+determine whether they are fit for use. Unit testing finds problems early
+in the development cycle.
+
+More information about PlatformIO Unit Testing:
+- https://docs.platformio.org/en/latest/advanced/unit-testing/index.html

--- a/wifi/esp32_receiver/README.md
+++ b/wifi/esp32_receiver/README.md
@@ -1,0 +1,20 @@
+# ESP32 Receiver (COM15)
+
+Transmitter ESP32로부터 WiFi 데이터를 수신하여 PC로 전달하는 브리지 역할을 합니다.
+
+## 상세 사양
+- **플랫폼**: PlatformIO (Arduino Framework)
+- **통신 포트**: COM15 (기본값)
+- **주요 역할**:
+  - WiFi를 통해 들어오는 TCP 데이터 수신
+  - 수신된 데이터를 USB-UART(PC)로 고속 전송 (Baudrate: 460800 권장)
+
+## 프로젝트 구조
+- `src/main.cpp`: WiFi 서버 설정 및 데이터 포워딩
+- `src/tcp_rx_task.cpp`: 네트워크 데이터 수신 처리
+- `src/wifi_server.cpp`: WiFi AP/Station 모드 설정
+
+## 사용 방법
+1. PlatformIO IDE에서 프로젝트를 엽니다.
+2. `platformio.ini`에서 보드 설정을 확인합니다.
+3. 빌드 후 업로드하면 Transmitter와 자동으로 페어링되어 데이터를 수신합니다.

--- a/wifi/esp32_transmitter/0420_board_to_esp32_01/.gitignore
+++ b/wifi/esp32_transmitter/0420_board_to_esp32_01/.gitignore
@@ -1,0 +1,5 @@
+.pio
+.vscode/.browse.c_cpp.db*
+.vscode/c_cpp_properties.json
+.vscode/launch.json
+.vscode/ipch

--- a/wifi/esp32_transmitter/0420_board_to_esp32_01/include/README
+++ b/wifi/esp32_transmitter/0420_board_to_esp32_01/include/README
@@ -1,0 +1,37 @@
+
+This directory is intended for project header files.
+
+A header file is a file containing C declarations and macro definitions
+to be shared between several project source files. You request the use of a
+header file in your project source file (C, C++, etc) located in `src` folder
+by including it, with the C preprocessing directive `#include'.
+
+```src/main.c
+
+#include "header.h"
+
+int main (void)
+{
+ ...
+}
+```
+
+Including a header file produces the same results as copying the header file
+into each source file that needs it. Such copying would be time-consuming
+and error-prone. With a header file, the related declarations appear
+in only one place. If they need to be changed, they can be changed in one
+place, and programs that include the header file will automatically use the
+new version when next recompiled. The header file eliminates the labor of
+finding and changing all the copies as well as the risk that a failure to
+find one copy will result in inconsistencies within a program.
+
+In C, the convention is to give header files names that end with `.h'.
+
+Read more about using header files in official GCC documentation:
+
+* Include Syntax
+* Include Operation
+* Once-Only Headers
+* Computed Includes
+
+https://gcc.gnu.org/onlinedocs/cpp/Header-Files.html

--- a/wifi/esp32_transmitter/0420_board_to_esp32_01/include/config.h
+++ b/wifi/esp32_transmitter/0420_board_to_esp32_01/include/config.h
@@ -1,0 +1,37 @@
+// config.h
+#pragma once
+#include <cstdint>
+#include <freertos/FreeRTOS.h>
+#include <freertos/ringbuf.h>
+
+// ─── LiDAR UART (Serial2) ─── RX only, TX unused ───────────────────────────
+#define LIDAR_RX_PIN        16
+#define LIDAR_BAUD          128000
+
+// ─── Board UART (Serial1) ────────────────────────────────────────────────────
+#define BOARD_RX_PIN        18
+#define BOARD_TX_PIN        19
+#define BOARD_BAUD          115200
+
+// ─── WiFi ── ESP32 #2 SoftAP 에 직접 연결 (공유기 우회) ─────────────────────
+#define WIFI_SSID           "ESP32_BRIDGE_AP"
+#define WIFI_PASSWORD       "bridge1234"
+
+// ─── TCP ── ESP32 #2 SoftAP 기본 IP ──────────────────────────────────────────
+#define PC_IP               "192.168.4.1"
+#define PC_PORT             8888
+
+// ─── TCP Framing Constants ────────────────────────────────────────────────────
+#define TCP_MAGIC_1         0xEFu
+#define TCP_MAGIC_2         0xBEu
+#define CHAN_LIDAR          0x01u
+#define CHAN_BOARD          0x02u
+#define CHAN_CMD_TO_BOARD   0x03u
+
+// ─── Ring Buffer Sizes ────────────────────────────────────────────────────────
+#define LIDAR_RING_SIZE     (16 * 1024)
+#define BOARD_RING_SIZE     ( 2 * 1024)
+
+// ─── Shared Ring Buffer Handles (defined in main.cpp) ─────────────────────────
+extern RingbufHandle_t xRingBuf_Lidar;
+extern RingbufHandle_t xRingBuf_Board;

--- a/wifi/esp32_transmitter/0420_board_to_esp32_01/include/tcp_tasks.h
+++ b/wifi/esp32_transmitter/0420_board_to_esp32_01/include/tcp_tasks.h
@@ -1,0 +1,5 @@
+#pragma once
+
+// Core 0에 핀: Ring Buffer → TCP 전송 / PC 명령 수신 → Serial1
+void tcpSendTask(void* pvParameters);
+void tcpReceiveTask(void* pvParameters);

--- a/wifi/esp32_transmitter/0420_board_to_esp32_01/include/uart_tasks.h
+++ b/wifi/esp32_transmitter/0420_board_to_esp32_01/include/uart_tasks.h
@@ -1,0 +1,5 @@
+#pragma once
+
+// Core 1에 핀: LiDAR(RX only) + Board UART 수신 → Ring Buffer push
+void uartLidarTask(void* pvParameters);
+void uartBoardTask(void* pvParameters);

--- a/wifi/esp32_transmitter/0420_board_to_esp32_01/include/wifi_tcp.h
+++ b/wifi/esp32_transmitter/0420_board_to_esp32_01/include/wifi_tcp.h
@@ -1,0 +1,10 @@
+#pragma once
+#include <Arduino.h>
+#include <WiFi.h>
+
+// tcpSendTask 단일 호출자 → critical section 불필요, tcpMux 제거
+extern WiFiClient tcpClient;
+
+void ensureWiFi();
+bool ensureTCP();
+bool tcpSendWrapped(uint8_t chan, const uint8_t* payload, uint16_t len);

--- a/wifi/esp32_transmitter/0420_board_to_esp32_01/lib/README
+++ b/wifi/esp32_transmitter/0420_board_to_esp32_01/lib/README
@@ -1,0 +1,46 @@
+
+This directory is intended for project specific (private) libraries.
+PlatformIO will compile them to static libraries and link into the executable file.
+
+The source code of each library should be placed in a separate directory
+("lib/your_library_name/[Code]").
+
+For example, see the structure of the following example libraries `Foo` and `Bar`:
+
+|--lib
+|  |
+|  |--Bar
+|  |  |--docs
+|  |  |--examples
+|  |  |--src
+|  |     |- Bar.c
+|  |     |- Bar.h
+|  |  |- library.json (optional. for custom build options, etc) https://docs.platformio.org/page/librarymanager/config.html
+|  |
+|  |--Foo
+|  |  |- Foo.c
+|  |  |- Foo.h
+|  |
+|  |- README --> THIS FILE
+|
+|- platformio.ini
+|--src
+   |- main.c
+
+Example contents of `src/main.c` using Foo and Bar:
+```
+#include <Foo.h>
+#include <Bar.h>
+
+int main (void)
+{
+  ...
+}
+
+```
+
+The PlatformIO Library Dependency Finder will find automatically dependent
+libraries by scanning project source files.
+
+More information about PlatformIO Library Dependency Finder
+- https://docs.platformio.org/page/librarymanager/ldf.html

--- a/wifi/esp32_transmitter/0420_board_to_esp32_01/src/main.cpp
+++ b/wifi/esp32_transmitter/0420_board_to_esp32_01/src/main.cpp
@@ -1,0 +1,66 @@
+#include <Arduino.h>
+#include <WiFi.h>
+#include <freertos/FreeRTOS.h>
+#include <freertos/task.h>
+#include <freertos/ringbuf.h>
+
+#include "config.h"
+#include "wifi_tcp.h"
+#include "uart_tasks.h"
+#include "tcp_tasks.h"
+
+// Ring buffer 실체 (config.h 에서 extern 선언됨)
+RingbufHandle_t xRingBuf_Lidar = NULL;
+RingbufHandle_t xRingBuf_Board = NULL;
+
+void setup() {
+    Serial.begin(115200);
+    Serial.println("\n[System] ESP32 Dual-Channel Bridge v3.0");
+
+    // LiDAR: RX only (TX=-1, 전송 불필요)
+    Serial2.begin(LIDAR_BAUD, SERIAL_8N1, LIDAR_RX_PIN, -1);
+    Serial.printf("[UART2] LiDAR  RX=GPIO%d (TX unused) BAUD=%d\n",
+                  LIDAR_RX_PIN, LIDAR_BAUD);
+
+    // Board (FPGA)
+    Serial1.begin(BOARD_BAUD, SERIAL_8N1, BOARD_RX_PIN, BOARD_TX_PIN);
+    Serial.printf("[UART1] Board  RX=GPIO%d TX=GPIO%d BAUD=%d\n",
+                  BOARD_RX_PIN, BOARD_TX_PIN, BOARD_BAUD);
+
+    // WiFi 초기 연결
+    WiFi.mode(WIFI_STA);
+    WiFi.begin(WIFI_SSID, WIFI_PASSWORD);
+    Serial.print("[WiFi] Connecting");
+    uint32_t t0 = millis();
+    while (WiFi.status() != WL_CONNECTED && millis() - t0 < 15000) {
+        delay(500);
+        Serial.print(".");
+    }
+    Serial.println(WiFi.status() == WL_CONNECTED
+        ? "\n[WiFi] OK: " + WiFi.localIP().toString()
+        : "\n[WiFi] Boot timeout (retry in tasks)");
+
+    // Ring Buffer 생성
+    xRingBuf_Lidar = xRingbufferCreate(LIDAR_RING_SIZE, RINGBUF_TYPE_BYTEBUF);
+    xRingBuf_Board = xRingbufferCreate(BOARD_RING_SIZE, RINGBUF_TYPE_BYTEBUF);
+    if (!xRingBuf_Lidar || !xRingBuf_Board) {
+        Serial.println("[ERROR] Ring buffer alloc failed! Halting.");
+        while (true) delay(1000);
+    }
+    Serial.printf("[RingBuf] Lidar=%uB  Board=%uB\n",
+                  LIDAR_RING_SIZE, BOARD_RING_SIZE);
+
+    // Core 1: UART 수신 (높은 우선순위로 FIFO 오버플로 방지)
+    xTaskCreatePinnedToCore(uartLidarTask, "LIDAR_RX", 4096, NULL, 5, NULL, 1);
+    xTaskCreatePinnedToCore(uartBoardTask, "BOARD_RX", 4096, NULL, 5, NULL, 1);
+
+    // Core 0: TCP 송수신
+    xTaskCreatePinnedToCore(tcpSendTask,    "TCP_TX",  8192, NULL, 4, NULL, 0);
+    xTaskCreatePinnedToCore(tcpReceiveTask, "TCP_RX",  8192, NULL, 3, NULL, 0);
+
+    Serial.println("[System] All 4 tasks launched.");
+}
+
+void loop() {
+    vTaskDelay(pdMS_TO_TICKS(1000));
+}

--- a/wifi/esp32_transmitter/0420_board_to_esp32_01/src/tcp_tasks.cpp
+++ b/wifi/esp32_transmitter/0420_board_to_esp32_01/src/tcp_tasks.cpp
@@ -1,0 +1,254 @@
+#include "tcp_tasks.h"
+#include "config.h"
+#include "wifi_tcp.h"
+#include <Arduino.h>
+#include <freertos/FreeRTOS.h>
+#include <freertos/task.h>
+#include <freertos/ringbuf.h>
+
+// ─── Task 3: TCP 전송 (Core 0, Priority 4) ───────────────────────────────────
+void tcpSendTask(void* /*pvParameters*/) {
+    Serial.printf("[TCP_TX] Task on Core %d\n", xPortGetCoreID());
+
+    bool wasConnected = false;
+
+    while (true) {
+        ensureWiFi();
+        if (!ensureTCP()) {
+            wasConnected = false;
+            continue;
+        }
+
+        // 재연결 직후 1회: Board 링버퍼 stale 데이터 드레인
+        // SHT40 과거 누적값 + 소멸된 RPi 펄스 제거 → 버스트 방지
+        if (!wasConnected) {
+            size_t dsz;
+            void* dump;
+            while ((dump = xRingbufferReceiveUpTo(
+                        xRingBuf_Board, &dsz, 0, 64)) != NULL) {
+                vRingbufferReturnItem(xRingBuf_Board, dump);
+            }
+            Serial.println("[TCP_TX] Board buf drained on reconnect");
+            wasConnected = true;
+        }
+
+        bool sent = false;
+
+        // Priority 1: Board (FPGA) channel
+        {
+            size_t sz = 0;
+            void* item = xRingbufferReceiveUpTo(
+                             xRingBuf_Board, &sz, 0, 64);
+            if (item && sz > 0) {
+                if (!tcpSendWrapped(CHAN_BOARD,
+                                    static_cast<uint8_t*>(item),
+                                    static_cast<uint16_t>(sz))) {
+                    Serial.println("[TCP_TX] Board write failed, reconnect");
+                    tcpClient.stop();
+                    wasConnected = false;
+                }
+                vRingbufferReturnItem(xRingBuf_Board, item);
+                sent = true;
+            }
+        }
+
+        // Priority 2: LiDAR channel (batch up to TCP MSS)
+        // LiDAR는 드레인 없이 이어서 전송
+        {
+            size_t sz = 0;
+            void* item = xRingbufferReceiveUpTo(
+                             xRingBuf_Lidar, &sz, pdMS_TO_TICKS(5), 1460);
+            if (item && sz > 0) {
+                if (!tcpSendWrapped(CHAN_LIDAR,
+                                    static_cast<uint8_t*>(item),
+                                    static_cast<uint16_t>(sz))) {
+                    Serial.println("[TCP_TX] LiDAR write failed, reconnect");
+                    tcpClient.stop();
+                    wasConnected = false;
+                }
+                vRingbufferReturnItem(xRingBuf_Lidar, item);
+                sent = true;
+            }
+        }
+
+        if (!sent) vTaskDelay(pdMS_TO_TICKS(1));
+    }
+}
+
+// ─── Task 4: TCP 수신 (Core 0, Priority 3) ───────────────────────────────────
+void tcpReceiveTask(void* /*pvParameters*/) {
+    Serial.printf("[TCP_RX] Task on Core %d\n", xPortGetCoreID());
+
+    enum RxState : uint8_t {
+        RX_MAGIC1 = 0, RX_MAGIC2, RX_CHAN,
+        RX_LEN_L, RX_LEN_H, RX_PAYLOAD
+    };
+
+    RxState  rxState = RX_MAGIC1;
+    uint8_t  rxChan  = 0;
+    uint16_t rxLen = 0, rxCnt = 0;
+    uint8_t  rxBuf[512];
+
+    while (true) {
+        ensureWiFi();
+        if (!ensureTCP()) { vTaskDelay(pdMS_TO_TICKS(100)); continue; }
+
+        while (tcpClient.available() > 0) {
+            uint8_t b = static_cast<uint8_t>(tcpClient.read());
+
+            switch (rxState) {
+                case RX_MAGIC1:
+                    rxState = (b == TCP_MAGIC_1) ? RX_MAGIC2 : RX_MAGIC1;
+                    break;
+                case RX_MAGIC2:
+                    if      (b == TCP_MAGIC_2) rxState = RX_CHAN;
+                    else if (b == TCP_MAGIC_1) rxState = RX_MAGIC2;
+                    else                       rxState = RX_MAGIC1;
+                    break;
+                case RX_CHAN:
+                    rxChan = b; rxState = RX_LEN_L;
+                    break;
+                case RX_LEN_L:
+                    rxLen = b; rxState = RX_LEN_H;
+                    break;
+                case RX_LEN_H:
+                    rxLen |= (static_cast<uint16_t>(b) << 8);
+                    rxCnt = 0;
+                    rxState = (rxLen == 0 || rxLen > sizeof(rxBuf))
+                              ? RX_MAGIC1 : RX_PAYLOAD;
+                    if (rxLen > sizeof(rxBuf))
+                        Serial.printf("[TCP_RX] Oversize %u, discard\n", rxLen);
+                    break;
+                case RX_PAYLOAD:
+                    rxBuf[rxCnt++] = b;
+                    if (rxCnt == rxLen) {
+                        if (rxChan == CHAN_CMD_TO_BOARD) {
+                            Serial1.write(rxBuf, rxLen);
+                            Serial.printf("[TCP_RX] CMD→Board %u B\n", rxLen);
+                        }
+                        rxState = RX_MAGIC1;
+                    }
+                    break;
+            }
+        }
+        vTaskDelay(pdMS_TO_TICKS(5));
+    }
+}
+
+// #include "tcp_tasks.h"
+// #include "config.h"
+// #include "wifi_tcp.h"
+// #include <Arduino.h>
+// #include <freertos/FreeRTOS.h>
+// #include <freertos/task.h>
+// #include <freertos/ringbuf.h>
+
+// // ─── Task 3: TCP 전송 (Core 0, Priority 4) ───────────────────────────────────
+// // Board 채널 우선(저속·저지연), LiDAR 채널 MSS 단위 배치
+// void tcpSendTask(void* /*pvParameters*/) {
+//     Serial.printf("[TCP_TX] Task on Core %d\n", xPortGetCoreID());
+
+//     while (true) {
+//         ensureWiFi();
+//         if (!ensureTCP()) continue;
+
+//         bool sent = false;
+
+//         // Priority 1: Board (FPGA) channel
+//         {
+//             size_t sz = 0;
+//             void* item = xRingbufferReceiveUpTo(
+//                              xRingBuf_Board, &sz, 0, 64);
+//             if (item && sz > 0) {
+//                 if (!tcpSendWrapped(CHAN_BOARD,
+//                                     static_cast<uint8_t*>(item),
+//                                     static_cast<uint16_t>(sz))) {
+//                     Serial.println("[TCP_TX] Board write failed, reconnect");
+//                     tcpClient.stop();
+//                 }
+//                 vRingbufferReturnItem(xRingBuf_Board, item);
+//                 sent = true;
+//             }
+//         }
+
+//         // Priority 2: LiDAR channel (batch up to TCP MSS)
+//         {
+//             size_t sz = 0;
+//             void* item = xRingbufferReceiveUpTo(
+//                              xRingBuf_Lidar, &sz, pdMS_TO_TICKS(5), 1460);
+//             if (item && sz > 0) {
+//                 if (!tcpSendWrapped(CHAN_LIDAR,
+//                                     static_cast<uint8_t*>(item),
+//                                     static_cast<uint16_t>(sz))) {
+//                     Serial.println("[TCP_TX] LiDAR write failed, reconnect");
+//                     tcpClient.stop();
+//                 }
+//                 vRingbufferReturnItem(xRingBuf_Lidar, item);
+//                 sent = true;
+//             }
+//         }
+
+//         if (!sent) vTaskDelay(pdMS_TO_TICKS(1));
+//     }
+// }
+
+// // ─── Task 4: TCP 수신 (Core 0, Priority 3) ───────────────────────────────────
+// // PC → ESP32 → Serial1(Basys3) 커맨드 포워딩
+// void tcpReceiveTask(void* /*pvParameters*/) {
+//     Serial.printf("[TCP_RX] Task on Core %d\n", xPortGetCoreID());
+
+//     enum RxState : uint8_t {
+//         RX_MAGIC1 = 0, RX_MAGIC2, RX_CHAN,
+//         RX_LEN_L, RX_LEN_H, RX_PAYLOAD
+//     };
+
+//     RxState  rxState = RX_MAGIC1;
+//     uint8_t  rxChan  = 0;
+//     uint16_t rxLen = 0, rxCnt = 0;
+//     uint8_t  rxBuf[512];
+
+//     while (true) {
+//         ensureWiFi();
+//         if (!ensureTCP()) { vTaskDelay(pdMS_TO_TICKS(100)); continue; }
+
+//         while (tcpClient.available() > 0) {
+//             uint8_t b = static_cast<uint8_t>(tcpClient.read());
+
+//             switch (rxState) {
+//                 case RX_MAGIC1:
+//                     rxState = (b == TCP_MAGIC_1) ? RX_MAGIC2 : RX_MAGIC1;
+//                     break;
+//                 case RX_MAGIC2:
+//                     if      (b == TCP_MAGIC_2) rxState = RX_CHAN;
+//                     else if (b == TCP_MAGIC_1) rxState = RX_MAGIC2;
+//                     else                       rxState = RX_MAGIC1;
+//                     break;
+//                 case RX_CHAN:
+//                     rxChan = b; rxState = RX_LEN_L;
+//                     break;
+//                 case RX_LEN_L:
+//                     rxLen = b; rxState = RX_LEN_H;
+//                     break;
+//                 case RX_LEN_H:
+//                     rxLen |= (static_cast<uint16_t>(b) << 8);
+//                     rxCnt = 0;
+//                     rxState = (rxLen == 0 || rxLen > sizeof(rxBuf))
+//                               ? RX_MAGIC1 : RX_PAYLOAD;
+//                     if (rxLen > sizeof(rxBuf))
+//                         Serial.printf("[TCP_RX] Oversize %u, discard\n", rxLen);
+//                     break;
+//                 case RX_PAYLOAD:
+//                     rxBuf[rxCnt++] = b;
+//                     if (rxCnt == rxLen) {
+//                         if (rxChan == CHAN_CMD_TO_BOARD) {
+//                             Serial1.write(rxBuf, rxLen);
+//                             Serial.printf("[TCP_RX] CMD→Board %u B\n", rxLen);
+//                         }
+//                         rxState = RX_MAGIC1;
+//                     }
+//                     break;
+//             }
+//         }
+//         vTaskDelay(pdMS_TO_TICKS(5));
+//     }
+// }

--- a/wifi/esp32_transmitter/0420_board_to_esp32_01/src/uart_tasks.cpp
+++ b/wifi/esp32_transmitter/0420_board_to_esp32_01/src/uart_tasks.cpp
@@ -1,0 +1,57 @@
+#include "uart_tasks.h"
+#include "config.h"
+#include <Arduino.h>
+#include <freertos/FreeRTOS.h>
+#include <freertos/task.h>
+#include <freertos/ringbuf.h>
+
+// ─── Task 1: LiDAR UART (Serial2, Core 1, Priority 5) ───────────────────────
+// 128 kbaud ≈ 12800 B/s. buf[256]로 Serial 내부 64B FIFO를 빠르게 비움.
+void uartLidarTask(void* /*pvParameters*/) {
+    uint8_t buf[256];
+    Serial.printf("[LIDAR] Task on Core %d\n", xPortGetCoreID());
+
+    while (true) {
+        int avail = Serial2.available();
+        if (avail > 0) {
+            int n = Serial2.readBytes(buf,
+                        min(avail, static_cast<int>(sizeof(buf))));
+            if (n > 0) {
+                if (xRingbufferSend(xRingBuf_Lidar, buf, n,
+                                    pdMS_TO_TICKS(5)) != pdTRUE) {
+                    // 오버플로 시 가장 오래된 청크 드롭 후 재시도
+                    size_t dsz;
+                    void* dump = xRingbufferReceiveUpTo(
+                                     xRingBuf_Lidar, &dsz, 0, 256);
+                    if (dump) vRingbufferReturnItem(xRingBuf_Lidar, dump);
+                    xRingbufferSend(xRingBuf_Lidar, buf, n, 0);
+                }
+            }
+        } else {
+            vTaskDelay(pdMS_TO_TICKS(1));
+        }
+    }
+}
+
+// ─── Task 2: Board UART (Serial1, Core 1, Priority 5) ───────────────────────
+// FPGA: 최소 1Hz SHT40, 비동기 RPi/CNN 이벤트
+void uartBoardTask(void* /*pvParameters*/) {
+    uint8_t buf[64];
+    Serial.printf("[BOARD] Task on Core %d\n", xPortGetCoreID());
+
+    while (true) {
+        int avail = Serial1.available();
+        if (avail > 0) {
+            int n = Serial1.readBytes(buf,
+                        min(avail, static_cast<int>(sizeof(buf))));
+            if (n > 0) {
+                if (xRingbufferSend(xRingBuf_Board, buf, n,
+                                    pdMS_TO_TICKS(10)) != pdTRUE) {
+                    Serial.println("[BOARD] Ring overflow, drop");
+                }
+            }
+        } else {
+            vTaskDelay(pdMS_TO_TICKS(2));
+        }
+    }
+}

--- a/wifi/esp32_transmitter/0420_board_to_esp32_01/src/wifi_tcp.cpp
+++ b/wifi/esp32_transmitter/0420_board_to_esp32_01/src/wifi_tcp.cpp
@@ -1,0 +1,45 @@
+#include "wifi_tcp.h"
+#include "config.h"
+#include <freertos/FreeRTOS.h>
+#include <freertos/task.h>
+
+WiFiClient   tcpClient;
+portMUX_TYPE tcpMux = portMUX_INITIALIZER_UNLOCKED;
+
+void ensureWiFi() {
+    if (WiFi.status() == WL_CONNECTED) return;
+    Serial.println("[WiFi] Reconnecting...");
+    WiFi.reconnect();
+    uint32_t t0 = millis();
+    while (WiFi.status() != WL_CONNECTED && millis() - t0 < 10000) {
+        vTaskDelay(pdMS_TO_TICKS(500));
+        Serial.print(".");
+    }
+    if (WiFi.status() == WL_CONNECTED)
+        Serial.println("\n[WiFi] Reconnected: " + WiFi.localIP().toString());
+}
+
+bool ensureTCP() {
+    if (tcpClient.connected()) return true;
+    Serial.printf("[TCP] Connecting to %s:%d\n", PC_IP, PC_PORT);
+    if (tcpClient.connect(PC_IP, PC_PORT)) {
+        Serial.println("[TCP] Connected!");
+        return true;
+    }
+    vTaskDelay(pdMS_TO_TICKS(1000));
+    return false;
+}
+
+// [0xEF][0xBE][chan][len_lo][len_hi][payload...]
+bool tcpSendWrapped(uint8_t chan, const uint8_t* payload, uint16_t len) {
+    uint8_t hdr[5] = {
+        TCP_MAGIC_1, TCP_MAGIC_2, chan,
+        static_cast<uint8_t>(len & 0xFFu),
+        static_cast<uint8_t>((len >> 8) & 0xFFu)
+    };
+    // portENTER_CRITICAL 제거 — tcpSendTask 단일 호출자이므로 불필요
+    // critical section 내 TCP write는 WDT 리셋 유발
+    int w1 = tcpClient.write(hdr, 5);
+    int w2 = tcpClient.write(payload, len);
+    return (w1 == 5 && w2 == static_cast<int>(len));
+}

--- a/wifi/esp32_transmitter/0420_board_to_esp32_01/test/README
+++ b/wifi/esp32_transmitter/0420_board_to_esp32_01/test/README
@@ -1,0 +1,11 @@
+
+This directory is intended for PlatformIO Test Runner and project tests.
+
+Unit Testing is a software testing method by which individual units of
+source code, sets of one or more MCU program modules together with associated
+control data, usage procedures, and operating procedures, are tested to
+determine whether they are fit for use. Unit testing finds problems early
+in the development cycle.
+
+More information about PlatformIO Unit Testing:
+- https://docs.platformio.org/en/latest/advanced/unit-testing/index.html

--- a/wifi/esp32_transmitter/README.md
+++ b/wifi/esp32_transmitter/README.md
@@ -1,0 +1,21 @@
+# ESP32 Transmitter (COM14)
+
+Lidar로부터 UART 데이터를 수신하여 WiFi를 통해 Receiver ESP32로 전달하는 펌웨어입니다.
+
+## 상세 사양
+- **플랫폼**: PlatformIO (Arduino Framework)
+- **통신 포트**: COM14 (기본값)
+- **주요 역할**:
+  - Lidar 하드웨어로부터 UART 데이터 수신
+  - 수신된 데이터를 TCP/IP 기반 WiFi 통신으로 전송
+  - 데이터의 무결성을 위한 래퍼(Wrapper) 처리
+
+## 프로젝트 구조
+- `src/main.cpp`: WiFi 연결 및 태스크 스케줄링
+- `src/uart_tasks.cpp`: Lidar 데이터 수신 전용 태스크
+- `src/wifi_tcp.cpp`: TCP 클라이언트 통신 로직
+
+## 사용 방법
+1. PlatformIO IDE에서 프로젝트를 엽니다.
+2. `platformio.ini` 설정을 확인한 후 빌드 및 업로드(Upload)를 진행합니다.
+3. `.pio` 및 `.vscode` 폴더는 환경에 따라 자동 생성되므로 포함되어 있지 않습니다.


### PR DESCRIPTION
작업 내용
- ESP32 WiFi 송수신용 펌웨어 코드 추가 (Transmitter/Receiver)
- FPGA(Basys3)용 SHT40 센서 데이터 패킷 처리 SystemVerilog 코드 추가
- 데이터 수신 및 파싱을 위한 PC용 Python 스크립트 추가
- 각 모듈별 상세 설명을 담은 README.md 문서 작성

참고 사항
- ESP32 Transmitter: COM14 사용
- ESP32 Receiver: COM15 사용
- 각 폴더 내 README를 통해 상세 실행 방법을 확인할 수 있습니다.